### PR TITLE
Feature/layout type and grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to KVitals will be documented in this file.
 
+## [2.5.0] - 2026-04-30
+
+### Added
+- **Layout Type** (`General` settings): Choose between **Horizontal** (default, unchanged) and **Vertical** layout for the compact panel view. In vertical mode, the metric value is displayed on top with the label/icon dimmed below — ideal for tall panels or icon-only display (#11).
+- **Metric Grouping** (`Metrics` settings — Grouping section):
+  - **Merge CPU & Temp**: Combines CPU temperature as a second value next to CPU usage (`CPU: 45% · 62°C`), using the same segment display as GPU. The CPU Temperature entry is hidden from the metric order list while merged.
+  - **Merge Battery & Power**: Combines power consumption as a second value next to battery level (`BAT: 87% · 12.4W`). Power Consumption entry is hidden from the metric order list while merged.
+  - **Split GPU Metrics**: Optionally break GPU usage, VRAM and temperature into separate panel entries instead of the default grouped display (default: grouped).
+
+### Changed
+- Metric order list now hides absorbed metrics when grouping is active (e.g. "CPU Temperature" disappears when "Merge CPU & Temp" is enabled), keeping the list clean and non-redundant.
+- `CompactView` refactored to use a `Loader`-based delegate system, enabling runtime layout switching without widget reload.
+
+### Fixed
+- `Unable to assign [undefined] to QColor` runtime error when CPU+Temp or Battery+Power merge was enabled — missing top-level `color` field on segmented metric objects.
+- Defensive `|| baseTextColor` fallback added to all value label color bindings in `CompactView`.
+
 ## [2.4.0] - 2026-04-01
 
 ### Added

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -43,6 +43,9 @@
         <entry name="mergeBatPwr" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="splitGpu" type="Bool">
+            <default>false</default>
+        </entry>
         <entry name="iconSize" type="Int">
             <default>12</default>
         </entry>

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -34,6 +34,15 @@
         <entry name="displayMode" type="String">
             <default>text</default>
         </entry>
+        <entry name="layoutType" type="String">
+            <default>horizontal</default>
+        </entry>
+        <entry name="mergeCpuTemp" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="mergeBatPwr" type="Bool">
+            <default>false</default>
+        </entry>
         <entry name="iconSize" type="Int">
             <default>12</default>
         </entry>

--- a/contents/ui/CompactView.qml
+++ b/contents/ui/CompactView.qml
@@ -14,7 +14,9 @@ RowLayout {
     required property string fontFamily
     required property int iconSize
     required property color baseTextColor
+    required property string layoutType
 
+    readonly property bool isVertical: layoutType === "vertical"
 
     signal toggleExpanded()
 
@@ -22,18 +24,68 @@ RowLayout {
         onTapped: compactRow.toggleExpanded()
     }
 
+    // Shared segments renderer
+    component SegmentsRow: Row {
+        required property var segments
+        spacing: 2
+
+        Repeater {
+            model: segments
+            delegate: Row {
+                required property var modelData
+                required property int index
+                spacing: 2
+
+                PlasmaComponents.Label {
+                    visible: index > 0
+                    text: "·"
+                    font.pixelSize: compactRow.effectiveFontSize
+                    font.family: compactRow.fontFamily
+                    color: compactRow.baseTextColor
+                    opacity: 0.5
+                }
+                PlasmaComponents.Label {
+                    text: modelData.value
+                    font.pixelSize: compactRow.effectiveFontSize
+                    font.family: compactRow.fontFamily
+                    color: modelData.color
+                }
+            }
+        }
+    }
+
     Repeater {
         model: compactRow.metricsModel
 
-        delegate: RowLayout {
+        delegate: Item {
             required property var modelData
             required property int index
 
+            implicitWidth:  loader.implicitWidth
+            implicitHeight: loader.implicitHeight
+
+            Loader {
+                id: loader
+                anchors.fill: parent
+                sourceComponent: compactRow.isVertical ? verticalDelegate : horizontalDelegate
+
+                property var itemData:  modelData
+                property int itemIndex: index
+            }
+        }
+    }
+
+    // ── Horizontal delegate (unchanged behaviour) ──────────────────────────
+
+    Component {
+        id: horizontalDelegate
+
+        RowLayout {
             spacing: 2
             Layout.fillHeight: true
 
             PlasmaComponents.Label {
-                visible: index > 0 && !modelData.hideSeparator
+                visible: itemIndex > 0 && !itemData.hideSeparator
                 text: "|"
                 font.pixelSize: compactRow.effectiveFontSize
                 font.family: compactRow.fontFamily
@@ -44,7 +96,7 @@ RowLayout {
 
             Kirigami.Icon {
                 visible: compactRow.useIcons
-                source: modelData.icon
+                source: itemData.icon
                 isMask: true
                 Layout.preferredWidth: compactRow.iconSize
                 Layout.preferredHeight: compactRow.iconSize
@@ -53,7 +105,7 @@ RowLayout {
 
             PlasmaComponents.Label {
                 visible: compactRow.useText
-                text: modelData.label
+                text: itemData.label
                 font.pixelSize: compactRow.effectiveFontSize
                 font.family: compactRow.fontFamily
                 color: compactRow.baseTextColor
@@ -61,41 +113,87 @@ RowLayout {
             }
 
             PlasmaComponents.Label {
-                text: modelData.value || ""
-                visible: !modelData.segments
+                visible: !itemData.segments
+                text: itemData.value || ""
                 font.pixelSize: compactRow.effectiveFontSize
                 font.family: compactRow.fontFamily
-                color: modelData.color
+                color: itemData.color
                 Layout.alignment: Qt.AlignVCenter
             }
 
-            Row {
-                visible: !!modelData.segments
-                spacing: 2
+            SegmentsRow {
+                visible: !!itemData.segments
+                segments: itemData.segments || []
+                Layout.alignment: Qt.AlignVCenter
+            }
+        }
+    }
+
+    // ── Vertical delegate (value on top, icon+label below) ─────────────────
+
+    Component {
+        id: verticalDelegate
+
+        RowLayout {
+            spacing: Kirigami.Units.smallSpacing
+            Layout.fillHeight: true
+
+            // Thin line separator between metrics
+            Rectangle {
+                visible: itemIndex > 0 && !itemData.hideSeparator
+                width: 1
+                Layout.fillHeight: true
+                color: compactRow.baseTextColor
+                opacity: 0.2
+            }
+
+            ColumnLayout {
+                spacing: 1
                 Layout.alignment: Qt.AlignVCenter
 
-                Repeater {
-                    model: modelData.segments || []
-                    delegate: Row {
-                        required property var modelData
-                        required property int index
-                        spacing: 2
+                // Top: value(s)
+                RowLayout {
+                    spacing: 0
+                    Layout.alignment: Qt.AlignHCenter
 
-                        PlasmaComponents.Label {
-                            visible: index > 0
-                            text: "·"
-                            font.pixelSize: compactRow.effectiveFontSize
-                            font.family: compactRow.fontFamily
-                            color: compactRow.baseTextColor
-                            opacity: 0.5
-                        }
+                    PlasmaComponents.Label {
+                        visible: !itemData.segments
+                        text: itemData.value || ""
+                        font.pixelSize: compactRow.effectiveFontSize
+                        font.family: compactRow.fontFamily
+                        font.bold: true
+                        color: itemData.color
+                        horizontalAlignment: Text.AlignHCenter
+                    }
 
-                        PlasmaComponents.Label {
-                            text: modelData.value
-                            font.pixelSize: compactRow.effectiveFontSize
-                            font.family: compactRow.fontFamily
-                            color: modelData.color
-                        }
+                    SegmentsRow {
+                        visible: !!itemData.segments
+                        segments: itemData.segments || []
+                    }
+                }
+
+                // Bottom: icon + label
+                RowLayout {
+                    spacing: 2
+                    Layout.alignment: Qt.AlignHCenter
+
+                    Kirigami.Icon {
+                        visible: compactRow.useIcons
+                        source: itemData.icon
+                        isMask: true
+                        Layout.preferredWidth:  Math.round(compactRow.iconSize * 0.85)
+                        Layout.preferredHeight: Math.round(compactRow.iconSize * 0.85)
+                        Layout.alignment: Qt.AlignVCenter
+                    }
+
+                    PlasmaComponents.Label {
+                        visible: compactRow.useText || !compactRow.useIcons
+                        text: itemData.label
+                        font.pixelSize: Math.max(8, compactRow.effectiveFontSize - 2)
+                        font.family: compactRow.fontFamily
+                        color: compactRow.baseTextColor
+                        opacity: 0.65
+                        Layout.alignment: Qt.AlignVCenter
                     }
                 }
             }

--- a/contents/ui/CompactView.qml
+++ b/contents/ui/CompactView.qml
@@ -117,7 +117,7 @@ RowLayout {
                 text: itemData.value || ""
                 font.pixelSize: compactRow.effectiveFontSize
                 font.family: compactRow.fontFamily
-                color: itemData.color
+                color: itemData.color || compactRow.baseTextColor
                 Layout.alignment: Qt.AlignVCenter
             }
 
@@ -162,7 +162,7 @@ RowLayout {
                         font.pixelSize: compactRow.effectiveFontSize
                         font.family: compactRow.fontFamily
                         font.bold: true
-                        color: itemData.color
+                        color: itemData.color || compactRow.baseTextColor
                         horizontalAlignment: Text.AlignHCenter
                     }
 
@@ -188,7 +188,10 @@ RowLayout {
 
                     PlasmaComponents.Label {
                         visible: compactRow.useText || !compactRow.useIcons
-                        text: itemData.label
+                        text: {
+                            var lbl = itemData.label || "";
+                            return lbl.endsWith(":") ? lbl.slice(0, -1) : lbl;
+                        }
                         font.pixelSize: Math.max(8, compactRow.effectiveFontSize - 2)
                         font.family: compactRow.fontFamily
                         color: compactRow.baseTextColor

--- a/contents/ui/CompactView.qml
+++ b/contents/ui/CompactView.qml
@@ -169,6 +169,7 @@ RowLayout {
                     SegmentsRow {
                         visible: !!itemData.segments
                         segments: itemData.segments || []
+                        Layout.alignment: Qt.AlignHCenter
                     }
                 }
 

--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -12,10 +12,14 @@ KCM.SimpleKCM {
     property alias cfg_fontSize: fontSizeSlider.value
     property string cfg_displayMode: "text"
     property string cfg_fontFamily: "monospace"
+    property string cfg_layoutType: "horizontal"
 
     readonly property var displayModes: ["text", "icons", "icons+text"]
     readonly property var displayModeLabels: [i18n("Text"), i18n("Icons"), i18n("Icons + Text")]
     readonly property bool iconsEnabled: cfg_displayMode !== "text"
+
+    readonly property var layoutTypes: ["horizontal", "vertical"]
+    readonly property var layoutTypeLabels: [i18n("Horizontal"), i18n("Vertical")]
 
     Kirigami.FormLayout {
 
@@ -29,6 +33,19 @@ KCM.SimpleKCM {
             }
             onActivated: {
                 cfg_displayMode = configPage.displayModes[currentIndex];
+            }
+        }
+
+        ComboBox {
+            id: layoutTypeCombo
+            Kirigami.FormData.label: i18n("Layout:")
+            model: configPage.layoutTypeLabels
+            currentIndex: {
+                var idx = configPage.layoutTypes.indexOf(cfg_layoutType);
+                return idx >= 0 ? idx : 0;
+            }
+            onActivated: {
+                cfg_layoutType = configPage.layoutTypes[currentIndex];
             }
         }
 

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -70,6 +70,15 @@ KCM.SimpleKCM {
             case "pwr":  cfg_showPower   = val; break;
             case "net":  cfg_showNetwork = val; break;
         }
+        // Reset merge toggles when a prerequisite metric is disabled
+        if (!val) {
+            if ((key === "cpu" || key === "temp") && cfg_mergeCpuTemp)
+                cfg_mergeCpuTemp = false;
+            if ((key === "bat" || key === "pwr") && cfg_mergeBatPwr)
+                cfg_mergeBatPwr = false;
+            if (key === "gpu" && cfg_splitGpu)
+                cfg_splitGpu = false;
+        }
     }
 
     function moveMetric(fromIndex, toIndex) {

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -18,6 +18,8 @@ KCM.SimpleKCM {
     property string cfg_networkInterface: "auto"
     property string cfg_batteryDevice: "auto"
     property string cfg_metricOrder: "cpu,ram,temp,gpu,bat,pwr,net"
+    property bool cfg_mergeCpuTemp: false
+    property bool cfg_mergeBatPwr: false
 
     property var ifaceList: ["auto"]
 
@@ -187,6 +189,45 @@ KCM.SimpleKCM {
             text: i18n("Empty value uses automatic detection.")
             opacity: 0.7
             visible: cfg_showBattery
+        }
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: i18n("Grouping")
+        }
+
+        CheckBox {
+            id: mergeCpuTempCheck
+            Kirigami.FormData.label: i18n("Merge CPU & Temp:")
+            checked: cfg_mergeCpuTemp
+            enabled: cfg_showCpu && cfg_showTemp
+            onToggled: cfg_mergeCpuTemp = checked
+        }
+
+        Label {
+            text: i18n("Shows CPU temperature as a second value next to CPU usage.")
+            opacity: 0.7
+            font.italic: true
+            visible: cfg_showCpu && cfg_showTemp
+            wrapMode: Text.WordWrap
+            Layout.maximumWidth: 300
+        }
+
+        CheckBox {
+            id: mergeBatPwrCheck
+            Kirigami.FormData.label: i18n("Merge Battery & Power:")
+            checked: cfg_mergeBatPwr
+            enabled: cfg_showBattery && cfg_showPower
+            onToggled: cfg_mergeBatPwr = checked
+        }
+
+        Label {
+            text: i18n("Shows power consumption as a second value next to battery level.")
+            opacity: 0.7
+            font.italic: true
+            visible: cfg_showBattery && cfg_showPower
+            wrapMode: Text.WordWrap
+            Layout.maximumWidth: 300
         }
     }
 }

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -20,6 +20,7 @@ KCM.SimpleKCM {
     property string cfg_metricOrder: "cpu,ram,temp,gpu,bat,pwr,net"
     property bool cfg_mergeCpuTemp: false
     property bool cfg_mergeBatPwr: false
+    property bool cfg_splitGpu: false
 
     property var ifaceList: ["auto"]
 
@@ -126,8 +127,14 @@ KCM.SimpleKCM {
                 model: metricsPage.currentOrder
 
                 delegate: RowLayout {
+                    required property var modelData
+                    required property int index
+
                     spacing: Kirigami.Units.smallSpacing
                     Layout.fillWidth: true
+                    // Hide metrics that are absorbed into a group
+                    visible: !(modelData === "temp" && cfg_mergeCpuTemp && cfg_showCpu) &&
+                             !(modelData === "pwr"  && cfg_mergeBatPwr  && cfg_showBattery)
 
                     CheckBox {
                         checked: metricsPage.isChecked(modelData)
@@ -226,6 +233,23 @@ KCM.SimpleKCM {
             opacity: 0.7
             font.italic: true
             visible: cfg_showBattery && cfg_showPower
+            wrapMode: Text.WordWrap
+            Layout.maximumWidth: 300
+        }
+
+        CheckBox {
+            id: splitGpuCheck
+            Kirigami.FormData.label: i18n("Split GPU metrics:")
+            checked: cfg_splitGpu
+            enabled: cfg_showGpu
+            onToggled: cfg_splitGpu = checked
+        }
+
+        Label {
+            text: i18n("Shows GPU usage, VRAM and temperature as separate entries instead of grouped.")
+            opacity: 0.7
+            font.italic: true
+            visible: cfg_showGpu
             wrapMode: Text.WordWrap
             Layout.maximumWidth: 300
         }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -25,6 +25,7 @@ PlasmoidItem {
     property string layoutType: Plasmoid.configuration.layoutType
     property bool mergeCpuTemp: Plasmoid.configuration.mergeCpuTemp
     property bool mergeBatPwr: Plasmoid.configuration.mergeBatPwr
+    property bool splitGpu: Plasmoid.configuration.splitGpu
     property int iconSize: Plasmoid.configuration.iconSize
     property string cpuIcon: Plasmoid.configuration.cpuIcon
     property string ramIcon: Plasmoid.configuration.ramIcon
@@ -146,6 +147,7 @@ PlasmoidItem {
                 if (key === "cpu" && root.showCpu && cpu.cpuValue) {
                     if (root.mergeCpuTemp && root.showTemp && temp.tempValue && temp.tempValue !== "--") {
                         items.push({ icon: root.cpuIcon, label: "CPU:",
+                                     color: root.cpuColor,
                                      segments: [
                                          { value: cpu.cpuValue,   color: root.cpuColor },
                                          { value: temp.tempValue, color: root.tempColor }
@@ -163,19 +165,29 @@ PlasmoidItem {
                     items.push({ icon: root.tempIcon, label: "TEMP:", value: temp.tempValue,
                                  color: root.tempColor });
                 else if (key === "gpu" && root.showGpu && gpu.hasGpuData) {
-                    var gpuSegs = [];
-                    if (gpu.hasGpuUsageData)
-                        gpuSegs.push({ value: gpu.gpuValue,    color: root.gpuColor });
-                    if (gpu.hasGpuVramData)
-                        gpuSegs.push({ value: gpu.gpuRamValue, color: root.baseTextColor });
-                    if (gpu.hasGpuTempData)
-                        gpuSegs.push({ value: gpu.gpuTempValue, color: root.gpuTempColor });
-                    items.push({ icon: root.gpuIcon, label: "GPU:", segments: gpuSegs,
-                                 color: root.gpuColor });
+                    if (root.splitGpu) {
+                        if (gpu.hasGpuUsageData)
+                            items.push({ icon: root.gpuIcon, label: "GPU:",  value: gpu.gpuValue,    color: root.gpuColor });
+                        if (gpu.hasGpuVramData)
+                            items.push({ icon: root.gpuIcon, label: "VRAM:", value: gpu.gpuRamValue, color: root.baseTextColor });
+                        if (gpu.hasGpuTempData)
+                            items.push({ icon: root.gpuIcon, label: "GTEMP:", value: gpu.gpuTempValue, color: root.gpuTempColor });
+                    } else {
+                        var gpuSegs = [];
+                        if (gpu.hasGpuUsageData)
+                            gpuSegs.push({ value: gpu.gpuValue,    color: root.gpuColor });
+                        if (gpu.hasGpuVramData)
+                            gpuSegs.push({ value: gpu.gpuRamValue, color: root.baseTextColor });
+                        if (gpu.hasGpuTempData)
+                            gpuSegs.push({ value: gpu.gpuTempValue, color: root.gpuTempColor });
+                        items.push({ icon: root.gpuIcon, label: "GPU:", segments: gpuSegs,
+                                     color: root.gpuColor });
+                    }
                 }
                 else if (key === "bat" && root.showBattery && battery.batValue) {
                     if (root.mergeBatPwr && root.showPower && battery.powerValue) {
                         items.push({ icon: root.batteryIcon, label: "BAT:",
+                                     color: root.batteryColor,
                                      segments: [
                                          { value: battery.batValue,   color: root.batteryColor },
                                          { value: battery.powerValue, color: root.baseTextColor }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -22,6 +22,9 @@ PlasmoidItem {
     property string networkInterface: Plasmoid.configuration.networkInterface
     property string batteryDevice: Plasmoid.configuration.batteryDevice
     property string displayMode: Plasmoid.configuration.displayMode
+    property string layoutType: Plasmoid.configuration.layoutType
+    property bool mergeCpuTemp: Plasmoid.configuration.mergeCpuTemp
+    property bool mergeBatPwr: Plasmoid.configuration.mergeBatPwr
     property int iconSize: Plasmoid.configuration.iconSize
     property string cpuIcon: Plasmoid.configuration.cpuIcon
     property string ramIcon: Plasmoid.configuration.ramIcon
@@ -140,19 +143,29 @@ PlasmoidItem {
             var items = [];
             for (var i = 0; i < root.orderedKeys.length; i++) {
                 var key = root.orderedKeys[i];
-                if (key === "cpu" && root.showCpu && cpu.cpuValue)
-                    items.push({ icon: root.cpuIcon, label: "CPU:", value: cpu.cpuValue,
-                                 color: root.cpuColor });
+                if (key === "cpu" && root.showCpu && cpu.cpuValue) {
+                    if (root.mergeCpuTemp && root.showTemp && temp.tempValue && temp.tempValue !== "--") {
+                        items.push({ icon: root.cpuIcon, label: "CPU:",
+                                     segments: [
+                                         { value: cpu.cpuValue,   color: root.cpuColor },
+                                         { value: temp.tempValue, color: root.tempColor }
+                                     ]});
+                    } else {
+                        items.push({ icon: root.cpuIcon, label: "CPU:", value: cpu.cpuValue,
+                                     color: root.cpuColor });
+                    }
+                }
                 else if (key === "ram" && root.showRam && memory.ramValue)
                     items.push({ icon: root.ramIcon, label: "RAM:", value: memory.ramValue,
                                  color: root.ramColor });
-                else if (key === "temp" && root.showTemp && temp.tempValue && temp.tempValue !== "--")
+                else if (key === "temp" && root.showTemp && temp.tempValue && temp.tempValue !== "--"
+                         && !(root.mergeCpuTemp && root.showCpu))
                     items.push({ icon: root.tempIcon, label: "TEMP:", value: temp.tempValue,
                                  color: root.tempColor });
                 else if (key === "gpu" && root.showGpu && gpu.hasGpuData) {
                     var gpuSegs = [];
                     if (gpu.hasGpuUsageData)
-                        gpuSegs.push({ value: gpu.gpuValue,   color: root.gpuColor });
+                        gpuSegs.push({ value: gpu.gpuValue,    color: root.gpuColor });
                     if (gpu.hasGpuVramData)
                         gpuSegs.push({ value: gpu.gpuRamValue, color: root.baseTextColor });
                     if (gpu.hasGpuTempData)
@@ -160,18 +173,30 @@ PlasmoidItem {
                     items.push({ icon: root.gpuIcon, label: "GPU:", segments: gpuSegs,
                                  color: root.gpuColor });
                 }
-                else if (key === "bat" && root.showBattery && battery.batValue)
-                    items.push({ icon: root.batteryIcon, label: "BAT:", value: battery.batValue,
-                                 color: root.batteryColor });
-                else if (key === "pwr" && root.showPower && battery.powerValue)
+                else if (key === "bat" && root.showBattery && battery.batValue) {
+                    if (root.mergeBatPwr && root.showPower && battery.powerValue) {
+                        items.push({ icon: root.batteryIcon, label: "BAT:",
+                                     segments: [
+                                         { value: battery.batValue,   color: root.batteryColor },
+                                         { value: battery.powerValue, color: root.baseTextColor }
+                                     ]});
+                    } else {
+                        items.push({ icon: root.batteryIcon, label: "BAT:", value: battery.batValue,
+                                     color: root.batteryColor });
+                    }
+                }
+                else if (key === "pwr" && root.showPower && battery.powerValue
+                         && !(root.mergeBatPwr && root.showBattery))
                     items.push({ icon: root.powerIcon, label: "PWR:", value: battery.powerValue,
                                  color: root.baseTextColor });
                 else if (key === "net" && root.showNetwork)
-                    items.push({ icon: root.networkIcon, label: "NET:", value: "↓" + network.netDownValue + " ↑" + network.netUpValue,
+                    items.push({ icon: root.networkIcon, label: "NET:",
+                                 value: "↓" + network.netDownValue + " ↑" + network.netUpValue,
                                  color: root.baseTextColor });
             }
             return items;
         }
+        layoutType: root.layoutType
         useIcons: root.useIcons
         useText: root.useText
         effectiveFontSize: root.effectiveFontSize

--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
             }
         ],
         "Website": "https://github.com/yassine20011/kvitals",
-        "Version": "2.4.0",
+        "Version": "2.5.0",
         "License": "GPL-3.0"
     },
     "KPackageStructure": "Plasma/Applet",


### PR DESCRIPTION
## Description

This PR introduces a new Layout Type system and Metric Grouping capabilities, making the widget much more adaptable to different panel setups (like vertical panels or tight spaces).

**Key Features:**
- **Layout Type (Horizontal/Vertical):** Added a new setting in the `General` tab to switch the layout of the compact view. The new "Vertical" mode stacks the metric value on top with a dimmed label/icon below, which works great for taller panels or compact setups.
- **Metric Grouping:** Added a new "Grouping" section in the `Metrics` tab:
  - **Merge CPU & Temp:** Combines CPU and Temperature into a single segmented entry (`CPU: 45% · 62°C`).
  - **Merge Battery & Power:** Combines Battery level and Power consumption into a single entry.
  - Absorbed metrics (like Temp or Power) are automatically hidden from the metric order list when their respective merge toggle is enabled to prevent confusion.
- **Split GPU Metrics:** Added an option to split the default grouped GPU display (usage/vram/temp) into separate individual entries.
- **Refactoring:** Rewrote `CompactView` to use a `Loader`-based delegate system, enabling seamless runtime layout switching.

## Related Issue

Resolves #11 #17 #24

## Testing

- [x] Tested on KDE Plasma 6.6.4
- [x] Distro: Fedora Linux 43
- [x] Widget installs cleanly with `install.sh`
- [x] Widget displays correctly in the panel

## Screenshots

<img width="960" height="767" alt="image" src="https://github.com/user-attachments/assets/aaff0f4f-bf16-4c0d-920d-c52bf42180ee" />
<br />
<img width="758" height="116" alt="image" src="https://github.com/user-attachments/assets/f2d97eb3-7942-4e79-933d-8111e6ee96f4" />
