### PR TITLE
feat: Add compact panel visibility options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ CPU: 26%  |  RAM: 8.8/39.0G  |  TEMP: 96°C  |  🔋BAT: 78%  |  PWR: +20W  |  N
 - **Display modes** — Text, Icons, or Icons + Text for the panel view
 - **Custom icons** — Pick any icon from your installed theme for each metric
 - **Font customization** — Choose any system font and size
-- **Configurable** — Toggle each metric, adjust refresh rate, organized in 3 settings tabs
+- **Configurable** — Toggle each metric, adjust refresh rate, tune colors, organized in 4 settings tabs
 - **Minimal footprint** — Native KDE KSysGuard sensors + QML, no heavy dependencies or excessive subprocesses
 - **Click to expand** — Detailed popup view with all stats
 
@@ -78,11 +78,12 @@ plasmashell --replace &
 
 ## Configuration
 
-Right-click the widget → **Configure KVitals...** to access settings in three tabs:
+Right-click the widget → **Configure KVitals...** to access settings in four tabs:
 
-- **General** — Display mode, icon size, font, update interval
-- **Metrics** — Toggle CPU, RAM, Temperature, Battery, Power, Network
+- **General** — Display mode, layout, icon size, font, update interval
+- **Metrics** — Toggle CPU, RAM, Temperature, GPU, Battery, Power, Network
 - **Icons** — Customize icons for each metric from your theme
+- **Colors** — Set custom font colors and optional threshold-based metric colors
 
 See the [full configuration reference](docs/configuration.md) for details.
 
@@ -119,6 +120,7 @@ kvitals/
         ├── configGeneral.qml       # General settings tab
         ├── configMetrics.qml       # Metrics settings tab
         ├── configIcons.qml         # Icons settings tab
+        ├── configColors.qml        # Colors settings tab
         └── sensors/                # Sensor modules
             ├── qmldir              # QML module definition
             ├── CpuSensors.qml      # CPU usage

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -25,6 +25,27 @@
         <entry name="showNetwork" type="Bool">
             <default>true</default>
         </entry>
+        <entry name="compactShowCpu" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="compactShowRam" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="compactShowTemp" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="compactShowGpu" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="compactShowBattery" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="compactShowPower" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="compactShowNetwork" type="Bool">
+            <default>true</default>
+        </entry>
         <entry name="networkInterface" type="String">
             <default>auto</default>
         </entry>

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -232,12 +232,7 @@ KCM.SimpleKCM {
                             text: metricsPage.metricLabels[modelData] || modelData
                             checked: metricsPage.isChecked(modelData)
 
-                            onToggled: {
-                                metricsPage.setChecked(modelData, checked);
-
-                                if (!checked)
-                                    metricsPage.setCompactChecked(modelData, false);
-                            }
+                            onToggled: metricsPage.setChecked(modelData, checked);
                         }
 
                         Item {

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -15,6 +15,13 @@ KCM.SimpleKCM {
     property bool cfg_showBattery
     property bool cfg_showPower
     property bool cfg_showNetwork
+    property bool cfg_compactShowCpu
+    property bool cfg_compactShowRam
+    property bool cfg_compactShowTemp
+    property bool cfg_compactShowGpu
+    property bool cfg_compactShowBattery
+    property bool cfg_compactShowPower
+    property bool cfg_compactShowNetwork
     property string cfg_networkInterface: "auto"
     property string cfg_batteryDevice: "auto"
     property string cfg_metricOrder: "cpu,ram,temp,gpu,bat,pwr,net"
@@ -27,17 +34,21 @@ KCM.SimpleKCM {
     readonly property var allKeys: ["cpu", "ram", "temp", "gpu", "bat", "pwr", "net"]
 
     readonly property var metricLabels: ({
-        "cpu":  i18n("CPU Usage"),
-        "ram":  i18n("RAM Usage"),
+        "cpu": i18n("CPU Usage"),
+        "ram": i18n("RAM Usage"),
         "temp": i18n("CPU Temperature"),
-        "gpu":  i18n("GPU Metrics"),
-        "bat":  i18n("Battery Status"),
-        "pwr":  i18n("Power Consumption"),
-        "net":  i18n("Network Speed")
+        "gpu": i18n("GPU Metrics"),
+        "bat": i18n("Battery Status"),
+        "pwr": i18n("Power Consumption"),
+        "net": i18n("Network Speed")
     })
 
     property var currentOrder: {
-        var keys = cfg_metricOrder.split(",").map(function(k) { return k.trim(); }).filter(function(k) { return k.length > 0 && metricLabels[k] !== undefined; });
+        var keys = cfg_metricOrder.split(",").map(function (k) {
+            return k.trim();
+        }).filter(function (k) {
+            return k.length > 0 && metricLabels[k] !== undefined;
+        });
         // Add any missing keys at the end
         for (var j = 0; j < allKeys.length; j++) {
             if (keys.indexOf(allKeys[j]) < 0) {
@@ -49,26 +60,67 @@ KCM.SimpleKCM {
 
     function isChecked(key) {
         switch (key) {
-            case "cpu":  return cfg_showCpu;
-            case "ram":  return cfg_showRam;
-            case "temp": return cfg_showTemp;
-            case "gpu":  return cfg_showGpu;
-            case "bat":  return cfg_showBattery;
-            case "pwr":  return cfg_showPower;
-            case "net":  return cfg_showNetwork;
+            case "cpu":
+                return cfg_showCpu;
+            case "ram":
+                return cfg_showRam;
+            case "temp":
+                return cfg_showTemp;
+            case "gpu":
+                return cfg_showGpu;
+            case "bat":
+                return cfg_showBattery;
+            case "pwr":
+                return cfg_showPower;
+            case "net":
+                return cfg_showNetwork;
+        }
+        return false;
+    }
+
+    function isCompactChecked(key) {
+        switch (key) {
+            case "cpu":
+                return cfg_compactShowCpu;
+            case "ram":
+                return cfg_compactShowRam;
+            case "temp":
+                return cfg_compactShowTemp;
+            case "gpu":
+                return cfg_compactShowGpu;
+            case "bat":
+                return cfg_compactShowBattery;
+            case "pwr":
+                return cfg_compactShowPower;
+            case "net":
+                return cfg_compactShowNetwork;
         }
         return false;
     }
 
     function setChecked(key, val) {
         switch (key) {
-            case "cpu":  cfg_showCpu     = val; break;
-            case "ram":  cfg_showRam     = val; break;
-            case "temp": cfg_showTemp    = val; break;
-            case "gpu":  cfg_showGpu     = val; break;
-            case "bat":  cfg_showBattery = val; break;
-            case "pwr":  cfg_showPower   = val; break;
-            case "net":  cfg_showNetwork = val; break;
+            case "cpu":
+                cfg_showCpu = val;
+                break;
+            case "ram":
+                cfg_showRam = val;
+                break;
+            case "temp":
+                cfg_showTemp = val;
+                break;
+            case "gpu":
+                cfg_showGpu = val;
+                break;
+            case "bat":
+                cfg_showBattery = val;
+                break;
+            case "pwr":
+                cfg_showPower = val;
+                break;
+            case "net":
+                cfg_showNetwork = val;
+                break;
         }
         // Reset merge toggles when a prerequisite metric is disabled
         if (!val) {
@@ -78,6 +130,32 @@ KCM.SimpleKCM {
                 cfg_mergeBatPwr = false;
             if (key === "gpu" && cfg_splitGpu)
                 cfg_splitGpu = false;
+        }
+    }
+
+    function setCompactChecked(key, val) {
+        switch (key) {
+            case "cpu":
+                cfg_compactShowCpu = val;
+                break;
+            case "ram":
+                cfg_compactShowRam = val;
+                break;
+            case "temp":
+                cfg_compactShowTemp = val;
+                break;
+            case "gpu":
+                cfg_compactShowGpu = val;
+                break;
+            case "bat":
+                cfg_compactShowBattery = val;
+                break;
+            case "pwr":
+                cfg_compactShowPower = val;
+                break;
+            case "net":
+                cfg_compactShowNetwork = val;
+                break;
         }
     }
 
@@ -108,11 +186,11 @@ KCM.SimpleKCM {
         engine: "executable"
         connectedSources: ["ls /sys/class/net/"]
 
-        onNewData: function(source, data) {
+        onNewData: function (source, data) {
             if (data["exit code"] !== 0) return;
             var raw = data["stdout"].trim();
             if (raw.length === 0) return;
-            var ifaces = raw.split("\n").filter(function(name) {
+            var ifaces = raw.split("\n").filter(function (name) {
                 return name !== "lo" && name.length > 0;
             });
             ifaces.unshift("auto");
@@ -141,17 +219,29 @@ KCM.SimpleKCM {
 
                     spacing: Kirigami.Units.smallSpacing
                     Layout.fillWidth: true
+
                     // Hide metrics that are absorbed into a group
                     visible: !(modelData === "temp" && cfg_mergeCpuTemp && cfg_showCpu) &&
-                             !(modelData === "pwr"  && cfg_mergeBatPwr  && cfg_showBattery)
+                        !(modelData === "pwr" && cfg_mergeBatPwr && cfg_showBattery)
 
                     CheckBox {
                         checked: metricsPage.isChecked(modelData)
                         onToggled: metricsPage.setChecked(modelData, checked)
+                        ToolTip.visible: hovered
+                        ToolTip.text: i18n("Enable this metric")
+                    }
+
+                    CheckBox {
+                        checked: metricsPage.isCompactChecked(modelData)
+                        enabled: metricsPage.isChecked(modelData)
+                        onToggled: metricsPage.setCompactChecked(modelData, checked)
+                        ToolTip.visible: hovered
+                        ToolTip.text: i18n("Show in compact panel")
                     }
 
                     Label {
                         text: metricsPage.metricLabels[modelData] || modelData
+                        enabled: metricsPage.isChecked(modelData)
                         Layout.fillWidth: true
                     }
 

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -213,7 +213,7 @@ KCM.SimpleKCM {
             Repeater {
                 model: metricsPage.currentOrder
 
-                delegate: RowLayout {
+                delegate: ColumnLayout {
                     required property var modelData
                     required property int index
 
@@ -224,43 +224,56 @@ KCM.SimpleKCM {
                     visible: !(modelData === "temp" && cfg_mergeCpuTemp && cfg_showCpu) &&
                         !(modelData === "pwr" && cfg_mergeBatPwr && cfg_showBattery)
 
-                    CheckBox {
-                        checked: metricsPage.isChecked(modelData)
-                        onToggled: metricsPage.setChecked(modelData, checked)
-                        ToolTip.visible: hovered
-                        ToolTip.text: i18n("Enable this metric")
-                    }
-
-                    CheckBox {
-                        checked: metricsPage.isCompactChecked(modelData)
-                        enabled: metricsPage.isChecked(modelData)
-                        onToggled: metricsPage.setCompactChecked(modelData, checked)
-                        ToolTip.visible: hovered
-                        ToolTip.text: i18n("Show in compact panel")
-                    }
-
-                    Label {
-                        text: metricsPage.metricLabels[modelData] || modelData
-                        enabled: metricsPage.isChecked(modelData)
+                    RowLayout {
                         Layout.fillWidth: true
+
+                        CheckBox {
+                            id: enabledCheck
+                            text: metricsPage.metricLabels[modelData] || modelData
+                            checked: metricsPage.isChecked(modelData)
+
+                            onToggled: {
+                                metricsPage.setChecked(modelData, checked);
+
+                                if (!checked)
+                                    metricsPage.setCompactChecked(modelData, false);
+                            }
+                        }
+
+                        Item {
+                            Layout.fillWidth: true
+                        }
+
+                        Button {
+                            icon.name: "arrow-up"
+                            enabled: index > 0
+                            flat: true
+                            implicitWidth: 32
+                            implicitHeight: 32
+                            onClicked: metricsPage.moveMetric(index, index - 1)
+                        }
+
+                        Button {
+                            icon.name: "arrow-down"
+                            enabled: index < metricsPage.currentOrder.length - 1
+                            flat: true
+                            implicitWidth: 32
+                            implicitHeight: 32
+                            onClicked: metricsPage.moveMetric(index, index + 1)
+                        }
                     }
 
-                    Button {
-                        icon.name: "arrow-up"
-                        enabled: index > 0
-                        flat: true
-                        implicitWidth: 32
-                        implicitHeight: 32
-                        onClicked: metricsPage.moveMetric(index, index - 1)
-                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        Layout.leftMargin: Kirigami.Units.gridUnit + Kirigami.Units.smallSpacing
 
-                    Button {
-                        icon.name: "arrow-down"
-                        enabled: index < metricsPage.currentOrder.length - 1
-                        flat: true
-                        implicitWidth: 32
-                        implicitHeight: 32
-                        onClicked: metricsPage.moveMetric(index, index + 1)
+                        CheckBox {
+                            text: i18n("Show in compact panel")
+                            checked: metricsPage.isCompactChecked(modelData)
+                            enabled: metricsPage.isChecked(modelData)
+
+                            onToggled: metricsPage.setCompactChecked(modelData, checked)
+                        }
                     }
                 }
             }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -19,6 +19,13 @@ PlasmoidItem {
     property bool showBattery: Plasmoid.configuration.showBattery
     property bool showPower: Plasmoid.configuration.showPower
     property bool showNetwork: Plasmoid.configuration.showNetwork
+    property bool compactShowCpu: Plasmoid.configuration.compactShowCpu
+    property bool compactShowRam: Plasmoid.configuration.compactShowRam
+    property bool compactShowTemp: Plasmoid.configuration.compactShowTemp
+    property bool compactShowGpu: Plasmoid.configuration.compactShowGpu
+    property bool compactShowBattery: Plasmoid.configuration.compactShowBattery
+    property bool compactShowPower: Plasmoid.configuration.compactShowPower
+    property bool compactShowNetwork: Plasmoid.configuration.compactShowNetwork
     property string networkInterface: Plasmoid.configuration.networkInterface
     property string batteryDevice: Plasmoid.configuration.batteryDevice
     property string displayMode: Plasmoid.configuration.displayMode
@@ -39,10 +46,12 @@ PlasmoidItem {
     property int effectiveFontSize: fontSize > 0 ? fontSize : Kirigami.Theme.smallFont.pixelSize
 
     property bool useIcons: displayMode === "icons" || displayMode === "icons+text"
-    property bool useText:  displayMode === "text"  || displayMode === "icons+text"
+    property bool useText: displayMode === "text" || displayMode === "icons+text"
 
     property string metricOrder: Plasmoid.configuration.metricOrder || "cpu,ram,temp,gpu,bat,pwr,net"
-    property var orderedKeys: metricOrder.split(",").map(function(k) { return k.trim(); })
+    property var orderedKeys: metricOrder.split(",").map(function (k) {
+        return k.trim();
+    })
 
     property int updateInterval: Plasmoid.configuration.updateInterval || 2000
 
@@ -75,32 +84,32 @@ PlasmoidItem {
 
     property color cpuColor: enableThresholdColors
         ? Utils.resolveColor(cpu.cpuNumericValue, cpuWarningThreshold, cpuCriticalThreshold,
-                             warningColor, criticalColor, baseTextColor, false)
+            warningColor, criticalColor, baseTextColor, false)
         : baseTextColor
 
     property color tempColor: enableThresholdColors
         ? Utils.resolveColor(temp.tempNumericValue, tempWarningThreshold, tempCriticalThreshold,
-                             warningColor, criticalColor, baseTextColor, false)
+            warningColor, criticalColor, baseTextColor, false)
         : baseTextColor
 
     property color ramColor: enableThresholdColors
         ? Utils.resolveColor(memory.ramPercentage, ramWarningThreshold, ramCriticalThreshold,
-                             warningColor, criticalColor, baseTextColor, false)
+            warningColor, criticalColor, baseTextColor, false)
         : baseTextColor
 
     property color gpuColor: enableThresholdColors
         ? Utils.resolveColor(gpu.gpuUsageNumber, gpuWarningThreshold, gpuCriticalThreshold,
-                             warningColor, criticalColor, baseTextColor, false)
+            warningColor, criticalColor, baseTextColor, false)
         : baseTextColor
 
     property color gpuTempColor: enableThresholdColors
         ? Utils.resolveColor(gpu.gpuTempNumber, gpuTempWarningThreshold, gpuTempCriticalThreshold,
-                             warningColor, criticalColor, baseTextColor, false)
+            warningColor, criticalColor, baseTextColor, false)
         : baseTextColor
 
     property color batteryColor: enableThresholdColors
         ? Utils.resolveColor(battery.batNumericValue, batteryWarningThreshold, batteryCriticalThreshold,
-                             warningColor, criticalColor, baseTextColor, true)
+            warningColor, criticalColor, baseTextColor, true)
         : baseTextColor
 
     // --- Sensor components ---
@@ -144,67 +153,92 @@ PlasmoidItem {
             var items = [];
             for (var i = 0; i < root.orderedKeys.length; i++) {
                 var key = root.orderedKeys[i];
-                if (key === "cpu" && root.showCpu && cpu.cpuValue) {
-                    if (root.mergeCpuTemp && root.showTemp && temp.tempValue && temp.tempValue !== "--") {
-                        items.push({ icon: root.cpuIcon, label: "CPU:",
-                                     color: root.cpuColor,
-                                     segments: [
-                                         { value: cpu.cpuValue,   color: root.cpuColor },
-                                         { value: temp.tempValue, color: root.tempColor }
-                                     ]});
+                if (key === "cpu" && root.showCpu && root.compactShowCpu && cpu.cpuValue) {
+                    if (root.mergeCpuTemp && root.showTemp && root.compactShowTemp && temp.tempValue && temp.tempValue !== "--") {
+                        items.push({
+                            icon: root.cpuIcon, label: "CPU:",
+                            color: root.cpuColor,
+                            segments: [
+                                {value: cpu.cpuValue, color: root.cpuColor},
+                                {value: temp.tempValue, color: root.tempColor}
+                            ]
+                        });
                     } else {
-                        items.push({ icon: root.cpuIcon, label: "CPU:", value: cpu.cpuValue,
-                                     color: root.cpuColor });
+                        items.push({
+                            icon: root.cpuIcon, label: "CPU:", value: cpu.cpuValue,
+                            color: root.cpuColor
+                        });
                     }
-                }
-                else if (key === "ram" && root.showRam && memory.ramValue)
-                    items.push({ icon: root.ramIcon, label: "RAM:", value: memory.ramValue,
-                                 color: root.ramColor });
-                else if (key === "temp" && root.showTemp && temp.tempValue && temp.tempValue !== "--"
-                         && !(root.mergeCpuTemp && root.showCpu))
-                    items.push({ icon: root.tempIcon, label: "TEMP:", value: temp.tempValue,
-                                 color: root.tempColor });
-                else if (key === "gpu" && root.showGpu && gpu.hasGpuData) {
+                } else if (key === "ram" && root.showRam && root.compactShowRam && memory.ramValue)
+                    items.push({
+                        icon: root.ramIcon, label: "RAM:", value: memory.ramValue,
+                        color: root.ramColor
+                    });
+                else if (key === "temp" && root.showTemp && root.compactShowTemp && temp.tempValue && temp.tempValue !== "--"
+                    && !(root.mergeCpuTemp && root.showCpu && root.compactShowCpu))
+                    items.push({
+                        icon: root.tempIcon, label: "TEMP:", value: temp.tempValue,
+                        color: root.tempColor
+                    });
+                else if (key === "gpu" && root.showGpu && root.compactShowGpu && gpu.hasGpuData) {
                     if (root.splitGpu) {
                         if (gpu.hasGpuUsageData)
-                            items.push({ icon: root.gpuIcon, label: "GPU:",  value: gpu.gpuValue,    color: root.gpuColor });
+                            items.push({icon: root.gpuIcon, label: "GPU:", value: gpu.gpuValue, color: root.gpuColor});
                         if (gpu.hasGpuVramData)
-                            items.push({ icon: root.gpuIcon, label: "VRAM:", value: gpu.gpuRamValue, color: root.baseTextColor });
+                            items.push({
+                                icon: root.gpuIcon,
+                                label: "VRAM:",
+                                value: gpu.gpuRamValue,
+                                color: root.baseTextColor
+                            });
                         if (gpu.hasGpuTempData)
-                            items.push({ icon: root.gpuIcon, label: "GTEMP:", value: gpu.gpuTempValue, color: root.gpuTempColor });
+                            items.push({
+                                icon: root.gpuIcon,
+                                label: "GTEMP:",
+                                value: gpu.gpuTempValue,
+                                color: root.gpuTempColor
+                            });
                     } else {
                         var gpuSegs = [];
                         if (gpu.hasGpuUsageData)
-                            gpuSegs.push({ value: gpu.gpuValue,    color: root.gpuColor });
+                            gpuSegs.push({value: gpu.gpuValue, color: root.gpuColor});
                         if (gpu.hasGpuVramData)
-                            gpuSegs.push({ value: gpu.gpuRamValue, color: root.baseTextColor });
+                            gpuSegs.push({value: gpu.gpuRamValue, color: root.baseTextColor});
                         if (gpu.hasGpuTempData)
-                            gpuSegs.push({ value: gpu.gpuTempValue, color: root.gpuTempColor });
-                        items.push({ icon: root.gpuIcon, label: "GPU:", segments: gpuSegs,
-                                     color: root.gpuColor });
+                            gpuSegs.push({value: gpu.gpuTempValue, color: root.gpuTempColor});
+                        items.push({
+                            icon: root.gpuIcon, label: "GPU:", segments: gpuSegs,
+                            color: root.gpuColor
+                        });
                     }
-                }
-                else if (key === "bat" && root.showBattery && battery.batValue) {
-                    if (root.mergeBatPwr && root.showPower && battery.powerValue) {
-                        items.push({ icon: root.batteryIcon, label: "BAT:",
-                                     color: root.batteryColor,
-                                     segments: [
-                                         { value: battery.batValue,   color: root.batteryColor },
-                                         { value: battery.powerValue, color: root.baseTextColor }
-                                     ]});
+                } else if (key === "bat" && root.showBattery && root.compactShowBattery && battery.batValue) {
+                    if (root.mergeBatPwr && root.showPower && root.compactShowPower && battery.powerValue) {
+                        items.push({
+                            icon: root.batteryIcon, label: "BAT:",
+                            color: root.batteryColor,
+                            segments: [
+                                {value: battery.batValue, color: root.batteryColor},
+                                {value: battery.powerValue, color: root.baseTextColor}
+                            ]
+                        });
                     } else {
-                        items.push({ icon: root.batteryIcon, label: "BAT:", value: battery.batValue,
-                                     color: root.batteryColor });
+                        items.push({
+                            icon: root.batteryIcon, label: "BAT:", value: battery.batValue,
+                            color: root.batteryColor
+                        });
                     }
-                }
-                else if (key === "pwr" && root.showPower && battery.powerValue
-                         && !(root.mergeBatPwr && root.showBattery))
-                    items.push({ icon: root.powerIcon, label: "PWR:", value: battery.powerValue,
-                                 color: root.baseTextColor });
-                else if (key === "net" && root.showNetwork)
-                    items.push({ icon: root.networkIcon, label: "NET:",
-                                 value: "↓" + network.netDownValue + " ↑" + network.netUpValue,
-                                 color: root.baseTextColor });
+                } else if (key === "pwr" && root.showPower && root.compactShowPower && battery.powerValue
+                    && !(root.mergeBatPwr && root.showBattery && root.compactShowBattery))
+                    items.push({
+                        icon: root.powerIcon, label: "PWR:", value: battery.powerValue,
+                        color: root.baseTextColor
+                    });
+                else if (key === "net" && root.showNetwork && root.compactShowNetwork)
+                    items.push({
+                        icon: root.networkIcon, label: "NET:",
+                        value: "↓" + network.netDownValue + " ↑" + network.netUpValue,
+                        color: root.baseTextColor
+                    });
             }
             return items;
         }
@@ -225,31 +259,46 @@ PlasmoidItem {
             for (var i = 0; i < root.orderedKeys.length; i++) {
                 var key = root.orderedKeys[i];
                 if (key === "cpu" && root.showCpu)
-                    items.push({ label: "CPU Usage", value: cpu.cpuValue,
-                                 color: root.cpuColor });
+                    items.push({
+                        label: "CPU Usage", value: cpu.cpuValue,
+                        color: root.cpuColor
+                    });
                 else if (key === "ram" && root.showRam)
-                    items.push({ label: "Memory", value: memory.ramValue,
-                                 color: root.ramColor });
+                    items.push({
+                        label: "Memory", value: memory.ramValue,
+                        color: root.ramColor
+                    });
                 else if (key === "temp" && root.showTemp && temp.tempValue !== "--")
-                    items.push({ label: "CPU Temp", value: temp.tempValue,
-                                 color: root.tempColor });
+                    items.push({
+                        label: "CPU Temp", value: temp.tempValue,
+                        color: root.tempColor
+                    });
                 else if (key === "gpu" && root.showGpu) {
-                    if (gpu.hasGpuUsageData) items.push({ label: "GPU Usage", value: gpu.gpuValue,
-                                                          color: root.gpuColor });
-                    if (gpu.hasGpuVramData) items.push({ label: "GPU VRAM", value: gpu.gpuRamValue,
-                                                         color: root.baseTextColor });
-                    if (gpu.hasGpuTempData) items.push({ label: "GPU Temp", value: gpu.gpuTempValue,
-                                                         color: root.gpuTempColor });
-                }
-                else if (key === "bat" && root.showBattery && battery.batValue)
-                    items.push({ label: "Battery", value: battery.batValue,
-                                 color: root.batteryColor });
+                    if (gpu.hasGpuUsageData) items.push({
+                        label: "GPU Usage", value: gpu.gpuValue,
+                        color: root.gpuColor
+                    });
+                    if (gpu.hasGpuVramData) items.push({
+                        label: "GPU VRAM", value: gpu.gpuRamValue,
+                        color: root.baseTextColor
+                    });
+                    if (gpu.hasGpuTempData) items.push({
+                        label: "GPU Temp", value: gpu.gpuTempValue,
+                        color: root.gpuTempColor
+                    });
+                } else if (key === "bat" && root.showBattery && battery.batValue)
+                    items.push({
+                        label: "Battery", value: battery.batValue,
+                        color: root.batteryColor
+                    });
                 else if (key === "pwr" && root.showPower && battery.powerValue)
-                    items.push({ label: "Power", value: battery.powerValue,
-                                 color: root.baseTextColor });
+                    items.push({
+                        label: "Power", value: battery.powerValue,
+                        color: root.baseTextColor
+                    });
                 else if (key === "net" && root.showNetwork) {
-                    items.push({ label: "Network ↓", value: network.netDownValue, color: root.baseTextColor });
-                    items.push({ label: "Network ↑", value: network.netUpValue, color: root.baseTextColor });
+                    items.push({label: "Network ↓", value: network.netDownValue, color: root.baseTextColor});
+                    items.push({label: "Network ↑", value: network.netUpValue, color: root.baseTextColor});
                 }
             }
             return items;
@@ -273,8 +322,7 @@ PlasmoidItem {
                 if (gpu.hasGpuUsageData) parts.push("GPU: " + gpu.gpuValue);
                 if (gpu.hasGpuVramData) parts.push("VRAM: " + gpu.gpuRamValue);
                 if (gpu.hasGpuTempData) parts.push("GPU TEMP: " + gpu.gpuTempValue);
-            }
-            else if (key === "bat" && root.showBattery && battery.batValue)
+            } else if (key === "bat" && root.showBattery && battery.batValue)
                 parts.push("BAT: " + battery.batValue);
             else if (key === "pwr" && root.showPower && battery.powerValue)
                 parts.push("PWR: " + battery.powerValue);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,12 +29,13 @@ A shared `Utils.qml` singleton provides formatting helpers (`formatBytes`, `form
 
 ## Orchestrator (`main.qml`)
 
-`main.qml` acts as a lightweight orchestrator (~140 lines):
+`main.qml` acts as a lightweight orchestrator:
 
 1. **Reads configuration** from `Plasmoid.configuration`
 2. **Instantiates sensor modules** with the configured `updateInterval`
 3. **Builds metrics models** using the `orderedKeys` array (derived from the `metricOrder` config)
-4. **Passes models** to `CompactView` and `FullView` for rendering
+4. **Applies view-specific visibility rules** such as `compactShow*` settings and compact grouping
+5. **Passes models** to `CompactView` and `FullView` for rendering
 
 ```
 main.qml
@@ -52,33 +53,36 @@ main.qml
 
 ### CompactView (Panel)
 
-A `RowLayout` with a `Repeater` that renders each enabled metric as:
+A `RowLayout` with a `Repeater` that renders each compact-visible metric as:
 - **Icon** (optional, via `Kirigami.Icon` with `isMask: true`)
 - **Label** (optional, e.g., "CPU:")
 - **Value** (always shown, e.g., "26%")
 - **Separator** (`|` between metrics)
 
-Visibility of icons/labels is controlled by the `displayMode` property.
+Visibility of icons/labels is controlled by the `displayMode` property. Metric inclusion is controlled by both the metric-level `show*` settings and the compact-panel `compactShow*` settings, allowing a metric to remain visible in the popup/tooltip while being hidden from the panel.
+
+The compact panel also supports horizontal and vertical delegates through the `layoutType` setting.
 
 !!! tip
     Icons use `isMask: true` to render as monochrome, matching the panel's text color regardless of the icon theme.
 
 ### FullView (Popup)
 
-A `ColumnLayout` with a `Repeater` showing a detailed row per metric with label and bold value, displayed when clicking the widget.
+A `ColumnLayout` with a `Repeater` showing a detailed row per enabled metric with label and bold value, displayed when clicking the widget.
 
 ### Tooltip
 
-Multi-line text showing all enabled metrics, displayed on hover.
+Multi-line text showing all enabled metrics, displayed on hover. Compact-panel visibility settings do not filter the tooltip.
 
 ## Configuration System
 
 ```
 config/main.xml          ← Config schema (entry names, types, defaults)
-config/config.qml        ← Tab registration (General, Metrics, Icons)
-ui/configGeneral.qml     ← General tab (display mode, font, interval)
-ui/configMetrics.qml     ← Metrics tab (show/hide toggles, metric order, network interface, battery device)
+config/config.qml        ← Tab registration (General, Metrics, Icons, Colors)
+ui/configGeneral.qml     ← General tab (display mode, layout, font, interval)
+ui/configMetrics.qml     ← Metrics tab (show/hide toggles, compact panel visibility, metric order, grouping, network interface, battery device)
 ui/configIcons.qml       ← Icons tab (per-metric icon picker)
+ui/configColors.qml      ← Colors tab (font color, warning/critical colors, thresholds)
 ```
 
 All config values are accessed in `main.qml` via `Plasmoid.configuration.<key>`.
@@ -88,7 +92,8 @@ All config values are accessed in `main.qml` via `Plasmoid.configuration.<key>`.
     2. Register it in `sensors/qmldir`
     3. Instantiate it in `main.qml`
     4. Add it to the `orderedKeys` loop in compact/full/tooltip builders
-    5. Add a `show*` config entry in `main.xml` and a checkbox in `configMetrics.qml`
+    5. Add `show*` and `compactShow*` config entries in `main.xml`
+    6. Add the metric and compact panel checkboxes in `configMetrics.qml`
 
 ## Project Structure
 
@@ -115,6 +120,7 @@ kvitals/
         ├── configGeneral.qml       # General settings tab
         ├── configMetrics.qml       # Metrics settings tab
         ├── configIcons.qml         # Icons settings tab
+        ├── configColors.qml        # Colors settings tab
         └── sensors/                # Sensor modules
             ├── qmldir              # QML module definition
             ├── CpuSensors.qml      # CPU usage

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,69 +1,139 @@
 # Configuration
 
-Right-click the widget → **Configure KVitals...** to open the settings dialog. Settings are organized into three tabs.
+Right-click the widget → **Configure KVitals...** to open the settings dialog. Settings are organized into four tabs.
 
 ## General Tab
 
-| Setting | Description | Default |
-|---------|-------------|---------|
-| **Display mode** | How metrics are shown in the panel | Text |
-| **Icon size** | Icon dimensions in pixels (only visible when using icons) | 12 px |
-| **Font** | Font family for all panel text (searchable dropdown of system fonts, editable) | monospace |
-| **Font size** | Text size in pixels. `0` uses the system default | 0 (system default) |
-| **Update interval** | How often stats are refreshed | 2.0 seconds |
+| Setting             | Description                                                                    | Default            |
+|---------------------|--------------------------------------------------------------------------------|--------------------|
+| **Display mode**    | How metrics are shown in the panel                                             | Text               |
+| **Layout**          | Compact panel layout direction                                                 | Horizontal         |
+| **Icon size**       | Icon dimensions in pixels (only visible when using icons)                      | 12 px              |
+| **Font**            | Font family for all panel text (searchable dropdown of system fonts, editable) | monospace          |
+| **Font size**       | Text size in pixels. `0` uses the system default                               | 0 (system default) |
+| **Update interval** | How often stats are refreshed                                                  | 2.0 seconds        |
 
 ### Display Modes
 
-| Mode | Description |
-|------|-------------|
-| **Text** | Labels + values: `CPU: 26%  \|  RAM: 8.8/39.0G` |
-| **Icons** | Icons + values only: `🖥 26%  \|  🧠 8.8/39.0G` |
+| Mode             | Description                                                   |
+|------------------|---------------------------------------------------------------|
+| **Text**         | Labels + values: `CPU: 26%  \|  RAM: 8.8/39.0G`               |
+| **Icons**        | Icons + values only: `🖥 26%  \|  🧠 8.8/39.0G`               |
 | **Icons + Text** | Icons + labels + values: `🖥 CPU: 26%  \|  🧠 RAM: 8.8/39.0G` |
 
 !!! tip "Saving Panel Space"
-    **Icons** mode is the most compact — great for small panels or when you have many metrics enabled.
+**Icons** mode is the most compact — great for small panels or when you have many metrics enabled.
+
+### Layout Types
+
+| Layout         | Description                                                  |
+|----------------|--------------------------------------------------------------|
+| **Horizontal** | Shows each compact metric in a single row, separated by `\|` |
+| **Vertical**   | Stacks the value above the icon                              |
 
 ## Metrics Tab
 
-| Setting | Description | Default |
-|---------|-------------|---------|
-| **Metric Order** | Drag and drop to rearrange the order of metrics on your panel | CPU, RAM, Temp, Bat, Power, Net |
-| **Show CPU usage** | Display CPU utilization percentage | On |
-| **Show RAM usage** | Display used/total memory | On |
-| **Show CPU temperature** | Display CPU temperature in °C | On |
-| **Show battery status** | Display battery percentage | On |
-| **Show power consumption** | Display power draw in watts | On |
-| **Show network speed** | Display download/upload speeds | On |
-| **Network interface** | Select network interface (`auto` or manual) | auto |
+| Setting                   | Description                                                                       | Default                              |
+|---------------------------|-----------------------------------------------------------------------------------|--------------------------------------|
+| **Metric Order**          | Use the up/down buttons to rearrange metrics in the panel                         | CPU, RAM, Temp, GPU, Bat, Power, Net |
+| **Metric enable toggles** | Enables or disables each metric                                                   | On                                   |
+| **Show in compact panel** | Controls whether each enabled metric appears in the panel representation          | On                                   |
+| **Network interface**     | Select network interface (`auto` or manual)                                       | auto                                 |
+| **Battery device**        | Leave empty for automatic battery detection, or enter a sensor device id manually | auto                                 |
+
+### Supported Metrics
+
+| Metric                | Compact Label | Description                                         |
+|-----------------------|---------------|-----------------------------------------------------|
+| **CPU Usage**         | `CPU:`        | CPU utilization percentage                          |
+| **RAM Usage**         | `RAM:`        | Used/total memory                                   |
+| **CPU Temperature**   | `TEMP:`       | CPU temperature in °C                               |
+| **GPU Metrics**       | `GPU:`        | GPU usage, VRAM, and GPU temperature when available |
+| **Battery Status**    | `BAT:`        | Battery percentage                                  |
+| **Power Consumption** | `PWR:`        | Power draw in watts                                 |
+| **Network Speed**     | `NET:`        | Download/upload speeds                              |
+
+### Compact Panel Visibility
+
+Each metric has two visibility controls:
+
+| Control                   | Effect                                                                                                                      |
+|---------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| **Metric checkbox**       | Enables the metric globally.                                                                                                |
+| **Show in compact panel** | Hides or shows the metric in the panel widget. The metric remains available in the dropdown menu and tooltip while enabled. |
+
+Use this when you still want to track a metric in the tooltip or dropdown but want to hide it from the panel to save
+space.
+
+### Grouping
+
+| Setting                   | Description                                                                                               | Default |
+|---------------------------|-----------------------------------------------------------------------------------------------------------|---------|
+| **Merge CPU & Temp**      | Shows CPU temperature as a second value next to CPU usage in the widget                                   | Off     |
+| **Merge Battery & Power** | Shows power consumption as a second value next to battery level in the widget                             | Off     |
+| **Split GPU metrics**     | Shows GPU usage, VRAM, and GPU temperature as separate compact panel entries instead of one grouped entry | Off     |
+
+Merged compact rows only absorb the second metric when both metrics are enabled and selected for the compact panel.
 
 ### Network Interface
 
-When set to `auto`, the widget natively aggregates the traffic across all active network connections using KDE's `network/all` sensor. This handles VPN routing and switching networks automatically.
+When set to `auto`, the widget natively aggregates the traffic across all active network connections using KDE's
+`network/all` sensor. This handles VPN routing and switching networks automatically.
 
-You can manually select a specific interface (e.g., `wlan0`, `enp3s0`) from the dropdown if you only want to monitor a single device.
+You can manually select a specific interface (e.g., `wlan0`, `enp3s0`) from the dropdown if you only want to monitor a
+single device.
 
 !!! note
-    The manual interface list is populated dynamically from `/sys/class/net/`.
+The manual interface list is populated dynamically from `/sys/class/net/`.
 
 ## Icons Tab
 
 Each metric has its own icon that can be customized:
 
-| Metric | Default Icon | Icon Name |
-|--------|-------------|-----------|
-| CPU | 🖥 | `cpu` |
-| RAM | 🧠 | `memory` |
-| Temperature | 🌡 | `temperature-normal` |
-| Battery | 🔋 | `battery-good` |
-| Power | ⚡ | `battery-charging-60` |
-| Network | 📶 | `network-wireless` |
+| Metric      | Default Icon | Icon Name             |
+|-------------|--------------|-----------------------|
+| CPU         | 🖥           | `cpu`                 |
+| RAM         | 🧠           | `memory`              |
+| Temperature | 🌡           | `temperature-normal`  |
+| GPU         | GPU          | `video-card`          |
+| Battery     | 🔋           | `battery-good`        |
+| Power       | ⚡            | `battery-charging-60` |
+| Network     | 📶           | `network-wireless`    |
 
-Click **"Change..."** to open KDE's native icon picker, which lets you browse and search all icons from your installed icon theme (Breeze, Papirus, Tela, etc.).
+Click **"Change..."** to open KDE's native icon picker, which lets you browse and search all icons from your installed
+icon theme (Breeze, Papirus, Tela, etc.).
 
 Click **"Reset to defaults"** to restore all icons to their default values.
 
 !!! note "Monochrome Rendering"
-    Icons are rendered with `isMask: true`, meaning they adopt the panel's text color (monochrome). This ensures visibility on both light and dark panels.
+Icons are rendered with `isMask: true`, meaning they adopt the panel's text color (monochrome). This ensures visibility
+on both light and dark panels.
 
 !!! tip "Finding Icons"
-    The icon picker shows all icons from your installed theme. Use the search bar to find icons by name — try keywords like "chip", "thermometer", "download", or "lightning".
+The icon picker shows all icons from your installed theme. Use the search bar to find icons by name — try keywords
+like "chip", "thermometer", "download", or "lightning".
+
+## Colors Tab
+
+| Setting                       | Description                                                  | Default                 |
+|-------------------------------|--------------------------------------------------------------|-------------------------|
+| **Use custom font color**     | Overrides the wudget text color with a custom color          | Off                     |
+| **Color**                     | Font color as a picked or typed `#RRGGBB` value              | Plasma theme text color |
+| **Enable threshold coloring** | Changes color of supported metric values based on thresholds | Off                     |
+| **Warning color**             | Color used when a warning threshold is reached               | `#e5a50a`               |
+| **Critical color**            | Color used when a critical threshold is reached              | `#da4453`               |
+
+Threshold coloring supports CPU usage, CPU temperature, RAM usage, GPU usage, GPU temperature, and battery level.
+
+| Metric          | Default warning color | Default critical color |
+|-----------------|-----------------------|------------------------|
+| CPU usage       | 70%                   | 90%                    |
+| CPU temperature | 60°C                  | 85°C                   |
+| RAM usage       | 70%                   | 90%                    |
+| GPU usage       | 70%                   | 90%                    |
+| GPU temperature | 60°C                  | 85°C                   |
+| Battery level   | 30%                   | 15%                    |
+
+!!! note "Battery Thresholds"
+Battery thresholds are inverted: warning and critical states trigger when the battery level falls _below_ the configured
+values.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,7 @@ Right-click the widget → **Configure KVitals...** to open the settings dialog.
 | **Icons + Text** | Icons + labels + values: `🖥 CPU: 26%  \|  🧠 RAM: 8.8/39.0G` |
 
 !!! tip "Saving Panel Space"
-**Icons** mode is the most compact — great for small panels or when you have many metrics enabled.
+    **Icons** mode is the most compact — great for small panels or when you have many metrics enabled.
 
 ### Layout Types
 
@@ -84,7 +84,7 @@ You can manually select a specific interface (e.g., `wlan0`, `enp3s0`) from the 
 single device.
 
 !!! note
-The manual interface list is populated dynamically from `/sys/class/net/`.
+    The manual interface list is populated dynamically from `/sys/class/net/`.
 
 ## Icons Tab
 
@@ -106,18 +106,18 @@ icon theme (Breeze, Papirus, Tela, etc.).
 Click **"Reset to defaults"** to restore all icons to their default values.
 
 !!! note "Monochrome Rendering"
-Icons are rendered with `isMask: true`, meaning they adopt the panel's text color (monochrome). This ensures visibility
-on both light and dark panels.
+    Icons are rendered with `isMask: true`, meaning they adopt the panel's text color (monochrome). This ensures
+    visibility on both light and dark panels.
 
 !!! tip "Finding Icons"
-The icon picker shows all icons from your installed theme. Use the search bar to find icons by name — try keywords
-like "chip", "thermometer", "download", or "lightning".
+    The icon picker shows all icons from your installed theme. Use the search bar to find icons by name — try keywords
+    like "chip", "thermometer", "download", or "lightning".
 
 ## Colors Tab
 
 | Setting                       | Description                                                  | Default                 |
 |-------------------------------|--------------------------------------------------------------|-------------------------|
-| **Use custom font color**     | Overrides the wudget text color with a custom color          | Off                     |
+| **Use custom font color**     | Overrides the widget text color with a custom color          | Off                     |
 | **Color**                     | Font color as a picked or typed `#RRGGBB` value              | Plasma theme text color |
 | **Enable threshold coloring** | Changes color of supported metric values based on thresholds | Off                     |
 | **Warning color**             | Color used when a warning threshold is reached               | `#e5a50a`               |
@@ -135,5 +135,5 @@ Threshold coloring supports CPU usage, CPU temperature, RAM usage, GPU usage, GP
 | Battery level   | 30%                   | 15%                    |
 
 !!! note "Battery Thresholds"
-Battery thresholds are inverted: warning and critical states trigger when the battery level falls _below_ the configured
-values.
+    Battery thresholds are inverted: warning and critical states trigger when the battery level falls _below_ the
+    configured values.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -36,8 +36,10 @@ Thanks for your interest in contributing to KVitals!
 ### Adding a New Metric
 
 1. **Sensors** — Find the relevant `org.kde.ksysguard.sensors` sensor ID using `kstatsviewer`
-2. **Settings** — Add checkbox to `configMetrics.qml`, icon picker to `configIcons.qml`
-5. **UI** — Add property bindings and model entry in `main.qml`
+2. **Settings** — Add `show*` and `compactShow*` entries to `contents/config/main.xml`
+3. **Configuration UI** — Add the metric and compact visibility checkboxes to `configMetrics.qml`
+4. **Icons** — Add an icon picker to `configIcons.qml`
+5. **UI** — Add property bindings and model entries in `main.qml`
 
 !!! note
     Don't forget to add a default icon name for the new metric in `configIcons.qml`'s reset button handler.
@@ -45,7 +47,7 @@ Thanks for your interest in contributing to KVitals!
 ### Adding a New Setting
 
 1. Add the entry to `contents/config/main.xml` with a default value
-2. Add the UI control to the appropriate config tab (`configGeneral.qml`, `configMetrics.qml`, or `configIcons.qml`)
+2. Add the UI control to the appropriate config tab (`configGeneral.qml`, `configMetrics.qml`, `configIcons.qml`, or `configColors.qml`)
 3. Bind the value in `main.qml` via `Plasmoid.configuration.<key>`
 
 ## Pull Requests

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,11 +8,11 @@ CPU: 26%  |  RAM: 8.8/39.0G  |  TEMP: 96°C  |  🔋BAT: 78%  |  PWR: +20W  |  N
 
 ## Features
 
-- **Live monitoring** — CPU, RAM, temperature, battery, power, network
+- **Live monitoring** — CPU, RAM, temperature, GPU, battery, power, network
 - **Display modes** — Text, Icons, or Icons + Text
 - **Custom icons** — Pick any icon from your installed KDE theme
 - **Font customization** — Choose any system font and size
-- **3-tab settings** — General, Metrics, and Icons
+- **Settings tabs** — General, Metrics, Icons, and Colors
 - **Minimal footprint** — Native KSysGuard integration + QML, no heavy dependencies
 
 ## Quick Start

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -77,6 +77,19 @@ qdbus --literal org.kde.ksystemstats1 /org/kde/ksystemstats1 org.kde.ksystemstat
 !!! tip
     On multi-GPU systems, per-GPU sensors such as `gpu/gpu1/*` may exist even when aggregate sensors are partial.
 
+## Metric Shows in Popup But Not Panel
+
+**Cause:** The metric is enabled, but its **Show in compact panel** checkbox is disabled in the Metrics settings.
+
+**Fix:**
+
+1. Open **Settings → Metrics**.
+2. Find the metric in the order list.
+3. Enable **Show in compact panel** under that metric.
+
+!!! note
+    Compact grouping also depends on compact visibility. For example, **Merge CPU & Temp** only shows temperature next to CPU when both metrics are enabled and selected for the compact panel.
+
 ## Widget Shows "KVitals" or "..."
 
 **Cause:** The KSysGuard daemon hasn't returned sensor data yet.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -65,9 +65,9 @@ plugins:
       markdown_description: >
         KVitals is a lightweight KDE Plasma 6 panel widget that displays live
         system vitals including CPU usage, memory usage, CPU temperature,
-        network upload/download speeds, and disk read/write speeds directly
-        in your panel. It uses a shell script backend with automatic network
-        interface detection and is fully configurable through a settings UI.
+        GPU metrics, battery status, power draw, and network upload/download
+        speeds directly in your panel. It uses native KDE KSysGuard sensors and 
+        is fully configurable through a settings UI.
       full_output: llms-full.txt
       sections:
         Getting started:


### PR DESCRIPTION
## Description

This PR adds checkboxes in the metrics option to set the visibility of a metric in the CompactView.
This enables the possibility of keeping track of a "less important" metric in the dropdown menu, while keeping the panel widget compact.

Documentation has been updated as well. I added this new feature, removed some outdated content and added some documentation around your new color settings.

## Related Issue

Closes #28

## Testing

- [X] Tested on Plasma 6.6.4, QT 6.11.0, Wayland
- [X] Distro: ArchLinux, Kernel 7.0.2
- [X] Widget installs cleanly with `install.sh`
- [X] Widget displays correctly in the panel

## Screenshots

<table>
<tr>
 <td>
<img width="337" height="156" alt="image" src="https://github.com/user-attachments/assets/0d935b21-10b3-49bd-8344-e254e7aedea0" />
 <td>
<img width="336" height="157" alt="image" src="https://github.com/user-attachments/assets/93157ee2-21c8-499c-b155-7167ef8cc98c" />
<tr>
<td>
<img width="940" height="788" alt="image" src="https://github.com/user-attachments/assets/29ec1725-aed8-4337-a9fc-0487cae8ce44" />
<td>
<img width="940" height="788" alt="image" src="https://github.com/user-attachments/assets/23538533-5d52-427b-ac9e-e40e3cf6fbc1" />
</table>