### PR TITLE
fix: inconsistent font bold styling across metrics (#30)

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -97,6 +97,9 @@
         <entry name="fontSize" type="Int">
             <default>0</default>
         </entry>
+        <entry name="fontBold" type="Bool">
+            <default>false</default>
+        </entry>
         <entry name="metricOrder" type="String">
             <default>cpu,ram,temp,gpu,bat,pwr,net</default>
         </entry>

--- a/contents/ui/CompactView.qml
+++ b/contents/ui/CompactView.qml
@@ -12,6 +12,7 @@ RowLayout {
     required property bool useText
     required property int effectiveFontSize
     required property string fontFamily
+    required property bool fontBold
     required property int iconSize
     required property color baseTextColor
     required property string layoutType
@@ -41,6 +42,7 @@ RowLayout {
                     text: "·"
                     font.pixelSize: compactRow.effectiveFontSize
                     font.family: compactRow.fontFamily
+                    font.bold: compactRow.fontBold
                     color: compactRow.baseTextColor
                     opacity: 0.5
                 }
@@ -48,6 +50,7 @@ RowLayout {
                     text: modelData.value
                     font.pixelSize: compactRow.effectiveFontSize
                     font.family: compactRow.fontFamily
+                    font.bold: compactRow.fontBold
                     color: modelData.color
                 }
             }
@@ -117,6 +120,7 @@ RowLayout {
                 text: itemData.value || ""
                 font.pixelSize: compactRow.effectiveFontSize
                 font.family: compactRow.fontFamily
+                font.bold: compactRow.fontBold
                 color: itemData.color || compactRow.baseTextColor
                 Layout.alignment: Qt.AlignVCenter
             }
@@ -161,7 +165,7 @@ RowLayout {
                         text: itemData.value || ""
                         font.pixelSize: compactRow.effectiveFontSize
                         font.family: compactRow.fontFamily
-                        font.bold: true
+                        font.bold: compactRow.fontBold
                         color: itemData.color || compactRow.baseTextColor
                         horizontalAlignment: Text.AlignHCenter
                     }

--- a/contents/ui/FullView.qml
+++ b/contents/ui/FullView.qml
@@ -11,6 +11,7 @@ ColumnLayout {
 
     required property var metricsModel
     required property color baseTextColor
+    required property bool fontBold
 
     PlasmaComponents.Label {
         text: "KVitals"
@@ -38,7 +39,7 @@ ColumnLayout {
             }
             PlasmaComponents.Label {
                 text: modelData.value
-                font.bold: true
+                font.bold: fullView.fontBold
                 color: modelData.color
                 horizontalAlignment: Text.AlignRight
             }

--- a/contents/ui/FullView.qml
+++ b/contents/ui/FullView.qml
@@ -15,7 +15,7 @@ ColumnLayout {
 
     PlasmaComponents.Label {
         text: "KVitals"
-        font.bold: true
+        font.bold: true // intentional: title always bold for visual hierarchy
         font.pixelSize: Kirigami.Theme.defaultFont.pixelSize * 1.2
         Layout.alignment: Qt.AlignHCenter
         Layout.bottomMargin: Kirigami.Units.smallSpacing

--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -10,6 +10,7 @@ KCM.SimpleKCM {
     property alias cfg_updateInterval: intervalSlider.value
     property alias cfg_iconSize: iconSizeSlider.value
     property alias cfg_fontSize: fontSizeSlider.value
+    property alias cfg_fontBold: fontBoldCheck.checked
     property string cfg_displayMode: "text"
     property string cfg_fontFamily: "monospace"
     property string cfg_layoutType: "horizontal"
@@ -96,6 +97,12 @@ KCM.SimpleKCM {
         Label {
             text: fontSizeSlider.value === 0 ? i18n("System default") : fontSizeSlider.value + " px"
             opacity: 0.7
+        }
+
+        CheckBox {
+            id: fontBoldCheck
+            Kirigami.FormData.label: i18n("Bold font:")
+            text: i18n("Bold")
         }
 
         Slider {

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -43,6 +43,7 @@ PlasmoidItem {
     property string networkIcon: Plasmoid.configuration.networkIcon
     property string fontFamily: Plasmoid.configuration.fontFamily
     property int fontSize: Plasmoid.configuration.fontSize
+    property bool fontBold: Plasmoid.configuration.fontBold
     property int effectiveFontSize: fontSize > 0 ? fontSize : Kirigami.Theme.smallFont.pixelSize
 
     property bool useIcons: displayMode === "icons" || displayMode === "icons+text"
@@ -247,6 +248,7 @@ PlasmoidItem {
         useText: root.useText
         effectiveFontSize: root.effectiveFontSize
         fontFamily: root.fontFamily
+        fontBold: root.fontBold
         iconSize: root.iconSize
         baseTextColor: root.baseTextColor
         onToggleExpanded: root.expanded = !root.expanded
@@ -254,6 +256,7 @@ PlasmoidItem {
 
     fullRepresentation: FullView {
         baseTextColor: root.baseTextColor
+        fontBold: root.fontBold
         metricsModel: {
             var items = [];
             for (var i = 0; i < root.orderedKeys.length; i++) {


### PR DESCRIPTION
## Description

- Remove hardcoded `font.bold: true` from CompactView vertical delegate and FullView value labels
- Add fontBold Bool config (default: false) to main.xml
- Add 'Bold font' CheckBox to General settings tab
- Thread fontBold through main.qml -> CompactView and FullView
- Apply `font.bold` consistently to all value labels and SegmentsRow (covers RAM/Network segment labels that were previously always bold)

## Related Issue

Fixes #30 

## Testing
- [x] Tested on KDE Plasma 6.6.4
- [x] Distro: Fedora Linux 43
- [x] Widget installs cleanly with install.sh
- [x] Widget displays correctly in the panel


## Screenshots

<img width="375" height="81" alt="image" src="https://github.com/user-attachments/assets/2d628729-3de8-499e-9de8-b18d601fd4df" />

<img width="960" height="772" alt="image" src="https://github.com/user-attachments/assets/0f88b887-b7e5-4740-b629-1d26e33830e1" />
