### PR TITLE
feat: add CPU frequency sensor with merge and full-view sub-item

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -7,6 +7,9 @@
         <entry name="showCpu" type="Bool">
             <default>true</default>
         </entry>
+        <entry name="showCpuFreq" type="Bool">
+            <default>false</default>
+        </entry>
         <entry name="showRam" type="Bool">
             <default>true</default>
         </entry>
@@ -59,6 +62,9 @@
             <default>horizontal</default>
         </entry>
         <entry name="mergeCpuTemp" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="mergeCpuFreq" type="Bool">
             <default>false</default>
         </entry>
         <entry name="mergeBatPwr" type="Bool">

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -26,8 +26,10 @@ KCM.SimpleKCM {
     property string cfg_batteryDevice: "auto"
     property string cfg_metricOrder: "cpu,ram,temp,gpu,bat,pwr,net"
     property bool cfg_mergeCpuTemp: false
+    property bool cfg_mergeCpuFreq: false
     property bool cfg_mergeBatPwr: false
     property bool cfg_splitGpu: false
+    property bool cfg_showCpuFreq: false
 
     property var ifaceList: ["auto"]
 
@@ -323,6 +325,36 @@ KCM.SimpleKCM {
             opacity: 0.7
             font.italic: true
             visible: cfg_showCpu && cfg_showTemp
+            wrapMode: Text.WordWrap
+            Layout.maximumWidth: 300
+        }
+
+        CheckBox {
+            id: showCpuFreqCheck
+            Kirigami.FormData.label: i18n("CPU Frequency:")
+            text: i18n("Show CPU frequency")
+            checked: cfg_showCpuFreq
+            enabled: cfg_showCpu
+            onToggled: {
+                cfg_showCpuFreq = checked;
+                if (!checked) cfg_mergeCpuFreq = false;
+            }
+        }
+
+        CheckBox {
+            id: mergeCpuFreqCheck
+            Kirigami.FormData.label: ""
+            text: i18n("Merge into CPU (compact view)")
+            checked: cfg_mergeCpuFreq
+            enabled: cfg_showCpu && cfg_showCpuFreq
+            onToggled: cfg_mergeCpuFreq = checked
+        }
+
+        Label {
+            text: i18n("Shows average CPU frequency (GHz/MHz). Merge appends it next to CPU usage in the panel.")
+            opacity: 0.7
+            font.italic: true
+            visible: cfg_showCpu && cfg_showCpuFreq
             wrapMode: Text.WordWrap
             Layout.maximumWidth: 300
         }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -31,6 +31,8 @@ PlasmoidItem {
     property string displayMode: Plasmoid.configuration.displayMode
     property string layoutType: Plasmoid.configuration.layoutType
     property bool mergeCpuTemp: Plasmoid.configuration.mergeCpuTemp
+    property bool mergeCpuFreq: Plasmoid.configuration.mergeCpuFreq
+    property bool showCpuFreq: Plasmoid.configuration.showCpuFreq
     property bool mergeBatPwr: Plasmoid.configuration.mergeBatPwr
     property bool splitGpu: Plasmoid.configuration.splitGpu
     property int iconSize: Plasmoid.configuration.iconSize
@@ -156,19 +158,21 @@ PlasmoidItem {
                 var key = root.orderedKeys[i];
                 if (key === "cpu" && root.showCpu && root.compactShowCpu && cpu.cpuValue) {
                     if (root.mergeCpuTemp && root.showTemp && root.compactShowTemp && temp.tempValue && temp.tempValue !== "--") {
+                        var segs = [{value: cpu.cpuValue, color: root.cpuColor},
+                                    {value: temp.tempValue, color: root.tempColor}];
+                        if (root.mergeCpuFreq && root.showCpuFreq)
+                            segs.push({value: cpu.cpuFreqValue, color: root.baseTextColor});
+                        items.push({icon: root.cpuIcon, label: "CPU:", color: root.cpuColor, segments: segs});
+                    } else if (root.mergeCpuFreq && root.showCpuFreq) {
                         items.push({
-                            icon: root.cpuIcon, label: "CPU:",
-                            color: root.cpuColor,
+                            icon: root.cpuIcon, label: "CPU:", color: root.cpuColor,
                             segments: [
                                 {value: cpu.cpuValue, color: root.cpuColor},
-                                {value: temp.tempValue, color: root.tempColor}
+                                {value: cpu.cpuFreqValue, color: root.baseTextColor}
                             ]
                         });
                     } else {
-                        items.push({
-                            icon: root.cpuIcon, label: "CPU:", value: cpu.cpuValue,
-                            color: root.cpuColor
-                        });
+                        items.push({icon: root.cpuIcon, label: "CPU:", value: cpu.cpuValue, color: root.cpuColor});
                     }
                 } else if (key === "ram" && root.showRam && root.compactShowRam && memory.ramValue)
                     items.push({
@@ -265,6 +269,11 @@ PlasmoidItem {
                     items.push({
                         label: "CPU Usage", value: cpu.cpuValue,
                         color: root.cpuColor
+                    });
+                if (key === "cpu" && root.showCpu && root.showCpuFreq)
+                    items.push({
+                        label: "CPU Frequency", value: cpu.cpuFreqValue,
+                        color: root.baseTextColor
                     });
                 else if (key === "ram" && root.showRam)
                     items.push({

--- a/contents/ui/sensors/CpuSensors.qml
+++ b/contents/ui/sensors/CpuSensors.qml
@@ -18,9 +18,25 @@ Item {
         return Math.round(cpuNumericValue) + "%";
     }
 
+    // Frequency in MHz from KSysGuard (unit type 302 = MHz); displays as GHz above 1000 MHz
+    readonly property string cpuFreqValue: {
+        if (freqSensor.status !== Sensors.Sensor.Ready || freqSensor.value == null)
+            return "...";
+        var mhz = freqSensor.value;
+        if (mhz >= 1000)
+            return (mhz / 1000).toFixed(2) + " GHz";
+        return Math.round(mhz) + " MHz";
+    }
+
     Sensors.Sensor {
         id: cpuSensor
         sensorId: "cpu/all/usage"
+        updateRateLimit: root.updateInterval
+    }
+
+    Sensors.Sensor {
+        id: freqSensor
+        sensorId: "cpu/all/averageFrequency"
         updateRateLimit: root.updateInterval
     }
 }


### PR DESCRIPTION
## Description

- Add `cpu/all/averageFrequency` sensor to CpuSensors.qml; auto-formats to GHz / MHz / kHz based on magnitude
- Add showCpuFreq (default off) and mergeCpuFreq config entries
- Add 'CPU Frequency' show toggle and 'Merge into CPU' checkbox to configMetrics.qml Grouping section
- Compact view: frequency appended as extra segment when mergeCpuFreq is on; works alongside mergeCpuTemp (3-segment CPU block)
- Full view: CPU Frequency appears as a sub-row under CPU Usage when showCpuFreq is enabled

## Related Issue

Fixes #31 

## Testing
- [x] Tested on KDE Plasma 6.6.4
- [x] Distro: Fedora Linux 43
- [x] Widget installs cleanly with install.sh
- [x] Widget displays correctly in the panel


## Screenshots

<img width="420" height="100" alt="image" src="https://github.com/user-attachments/assets/f8753e45-2758-4e5d-97fb-458006b536ae" />

<br />
<img width="675" height="351" alt="image" src="https://github.com/user-attachments/assets/acb00163-9844-4101-86d3-dca1c6768129" />

