### PR TITLE
Chore/release 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to KVitals will be documented in this file.
 ## [2.6.0] - 2026-05-10
 
 ### Added
+- **Compact Panel Visibility** (`Metrics` settings): Each metric now has an independent "Show in compact panel" toggle, allowing metrics to appear in the full popup view but stay hidden from the panel bar (#29, thanks @keiishu). Disabling a metric preserves its compact visibility state for when it is re-enabled.
 - **CPU Frequency** (`Metrics` settings): Display the average CPU frequency in the widget. Auto-formats as GHz (≥ 1000 MHz) or MHz (#33).
   - **Merge into CPU** (compact view): Appends frequency as a second segment next to CPU usage (`CPU: 34% · 3.20 GHz`). Compatible with Merge CPU & Temp — all three values appear as segments.
   - **Full view sub-item**: When enabled, CPU Frequency appears as a dedicated row directly under CPU Usage in the popup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to KVitals will be documented in this file.
 
+## [2.6.0] - 2026-05-10
+
+### Added
+- **CPU Frequency** (`Metrics` settings): Display the average CPU frequency in the widget. Auto-formats as GHz (≥ 1000 MHz) or MHz (#33).
+  - **Merge into CPU** (compact view): Appends frequency as a second segment next to CPU usage (`CPU: 34% · 3.20 GHz`). Compatible with Merge CPU & Temp — all three values appear as segments.
+  - **Full view sub-item**: When enabled, CPU Frequency appears as a dedicated row directly under CPU Usage in the popup.
+- **Bold Font** (`General` settings): Toggle bold styling for all metric value labels across compact and full views (#30). Defaults to off.
+
+### Fixed
+- Inconsistent font weight across metrics in vertical layout: RAM and Network values (rendered via `SegmentsRow`) were always bold while CPU/GPU were not. All value labels now follow the new Bold Font setting uniformly.
+
 ## [2.5.0] - 2026-04-30
 
 ### Added

--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
             }
         ],
         "Website": "https://github.com/yassine20011/kvitals",
-        "Version": "2.5.0",
+        "Version": "2.6.0",
         "License": "GPL-3.0"
     },
     "KPackageStructure": "Plasma/Applet",


### PR DESCRIPTION
## Description

This pull request updates KVitals to version 2.6.0, introducing several new features and improvements focused on metric visibility, CPU frequency display, and font styling options. It also addresses a UI consistency issue with font weights across different metrics.

New features and enhancements:

**Metric visibility and display:**
* Added independent "Show in compact panel" toggles for each metric in `Metrics` settings, allowing users to control which metrics appear in the compact panel versus the full popup view. Disabling a metric now preserves its compact visibility state for later re-enabling.

**CPU frequency display:**
* Introduced CPU Frequency as a new metric, showing the average CPU frequency in the widget. This value is auto-formatted (GHz or MHz) and can be merged into the compact CPU segment or shown as a dedicated row in the full view. Compatible with merged CPU & Temp display.

**UI customization and consistency:**
* Added a "Bold Font" toggle in `General` settings to control bold styling for all metric value labels, affecting both compact and full views. Default is off.
* Fixed inconsistent font weight in vertical layouts, ensuring all metric value labels follow the new Bold Font setting.

Other changes:

* Updated the version in `metadata.json` from 2.5.0 to 2.6.0.