### PR TITLE
feat(gpu): multi-GPU support, custom labels, and dGPU wakeup fix (#22…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ All notable changes to KVitals will be documented in this file.
 ### Fixed
 
 - **Unintended dGPU Wakeup** on hybrid GPU laptops (Intel/AMD + NVIDIA setups using `supergfxctl` / `asusctl`): The previous implementation used permanent `Sensors.Sensor` subscriptions for up to 6 hardcoded GPU slots. These subscriptions polled every GPU continuously, preventing the dGPU from entering its suspended/power-save state even when it was idle (#26).
-  - **Root cause removed**: All hardcoded per-slot `Sensors.Sensor` probes (`probe0`–`probe5`) have been eliminated from both `GpuSensors.qml` and the settings dialog.
   - **New architecture**: Discovery uses `SensorTreeModel` + `KDescendantsProxyModel` (pure metadata query, no value subscriptions). Data polling uses a single `SensorDataModel` constrained strictly to the GPUs the user has selected.
   - **Result**: Deselecting a GPU in settings stops all polling for that GPU immediately. On hybrid setups, unchecking the dGPU allows it to fully suspend.
   - **Note**: If the dGPU remains active even after unchecking it in KVitals, the cause is likely unrelated — some Xwayland applications keep the GPU awake independently of any sensor polling. This is a system/compositor-level behavior outside the scope of KVitals.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,28 @@
 
 All notable changes to KVitals will be documented in this file.
 
+## [2.7.0] - 2026-05-15
+
+### Added
+
+- **Multi-GPU Support** (`Metrics` settings — GPU Selection): On systems with more than one GPU, each GPU is now listed individually as a separate metric in both the compact panel and the full popup view (#22). Works automatically — no configuration needed on single-GPU machines.
+  - Each GPU is detected dynamically via `SensorTreeModel` metadata; no persistent subscriptions run during discovery.
+  - The GPU Selection section in settings shows all discovered GPUs with independent enable/disable checkboxes.
+- **GPU Custom Labels** (`Metrics` settings — GPU Selection): On multi-GPU systems, each GPU entry in the panel shows a customizable label. Type a name in the **Label** field (e.g. `iGPU`, `dGPU`) to override the default `GPU 1` / `GPU 2` identifiers. Leave it empty to keep the default numbering.
+- **Hybrid GPU power hint**: When two or more GPUs are detected, a contextual note appears in the GPU Selection section explaining that unchecking the discrete GPU prevents KVitals from polling it, allowing it to suspend when idle.
+
+### Fixed
+
+- **Unintended dGPU Wakeup** on hybrid GPU laptops (Intel/AMD + NVIDIA setups using `supergfxctl` / `asusctl`): The previous implementation used permanent `Sensors.Sensor` subscriptions for up to 6 hardcoded GPU slots. These subscriptions polled every GPU continuously, preventing the dGPU from entering its suspended/power-save state even when it was idle (#26).
+  - **Root cause removed**: All hardcoded per-slot `Sensors.Sensor` probes (`probe0`–`probe5`) have been eliminated from both `GpuSensors.qml` and the settings dialog.
+  - **New architecture**: Discovery uses `SensorTreeModel` + `KDescendantsProxyModel` (pure metadata query, no value subscriptions). Data polling uses a single `SensorDataModel` constrained strictly to the GPUs the user has selected.
+  - **Result**: Deselecting a GPU in settings stops all polling for that GPU immediately. On hybrid setups, unchecking the dGPU allows it to fully suspend.
+  - **Note**: If the dGPU remains active even after unchecking it in KVitals, the cause is likely unrelated — some Xwayland applications keep the GPU awake independently of any sensor polling. This is a system/compositor-level behavior outside the scope of KVitals.
+
 ## [2.6.0] - 2026-05-10
 
 ### Added
+
 - **Compact Panel Visibility** (`Metrics` settings): Each metric now has an independent "Show in compact panel" toggle, allowing metrics to appear in the full popup view but stay hidden from the panel bar (#29, thanks @keiishu). Disabling a metric preserves its compact visibility state for when it is re-enabled.
 - **CPU Frequency** (`Metrics` settings): Display the average CPU frequency in the widget. Auto-formats as GHz (≥ 1000 MHz) or MHz (#33).
   - **Merge into CPU** (compact view): Appends frequency as a second segment next to CPU usage (`CPU: 34% · 3.20 GHz`). Compatible with Merge CPU & Temp — all three values appear as segments.
@@ -12,11 +31,13 @@ All notable changes to KVitals will be documented in this file.
 - **Bold Font** (`General` settings): Toggle bold styling for all metric value labels across compact and full views (#30). Defaults to off.
 
 ### Fixed
+
 - Inconsistent font weight across metrics in vertical layout: RAM and Network values (rendered via `SegmentsRow`) were always bold while CPU/GPU were not. All value labels now follow the new Bold Font setting uniformly.
 
 ## [2.5.0] - 2026-04-30
 
 ### Added
+
 - **Layout Type** (`General` settings): Choose between **Horizontal** (default, unchanged) and **Vertical** layout for the compact panel view. In vertical mode, the metric value is displayed on top with the label/icon dimmed below — ideal for tall panels or icon-only display (#11).
 - **Metric Grouping** (`Metrics` settings — Grouping section):
   - **Merge CPU & Temp**: Combines CPU temperature as a second value next to CPU usage (`CPU: 45% · 62°C`), using the same segment display as GPU. The CPU Temperature entry is hidden from the metric order list while merged.
@@ -24,16 +45,19 @@ All notable changes to KVitals will be documented in this file.
   - **Split GPU Metrics**: Optionally break GPU usage, VRAM and temperature into separate panel entries instead of the default grouped display (default: grouped).
 
 ### Changed
+
 - Metric order list now hides absorbed metrics when grouping is active (e.g. "CPU Temperature" disappears when "Merge CPU & Temp" is enabled), keeping the list clean and non-redundant.
 - `CompactView` refactored to use a `Loader`-based delegate system, enabling runtime layout switching without widget reload.
 
 ### Fixed
+
 - `Unable to assign [undefined] to QColor` runtime error when CPU+Temp or Battery+Power merge was enabled — missing top-level `color` field on segmented metric objects.
 - Defensive `|| baseTextColor` fallback added to all value label color bindings in `CompactView`.
 
 ## [2.4.0] - 2026-04-01
 
 ### Added
+
 - **Custom Font Color**: Override the widget font color to match your panel theme (#20). Configurable via the new **Colors** settings tab.
 - **Threshold-Based Coloring**: Metric values dynamically change color when they exceed configurable warning/critical thresholds (#12). Supported metrics:
   - CPU usage (default: warning 70%, critical 90%)
@@ -47,15 +71,18 @@ All notable changes to KVitals will be documented in this file.
 - `Utils.resolveColor()` function for flexible threshold-triggered color resolution.
 
 ### Fixed
+
 - Fixed the Colors tab color picker turning white after selecting a color; it now uses a stable native platform color dialog and preserves the selected swatch correctly.
 
 ### Notes
+
 - Network and Power metrics are excluded from threshold coloring (no meaningful universal threshold).
 - Both features are **opt-in** — disabled by default. Existing users are unaffected.
 
 ## [2.3.0] - 2026-03-13
 
 ### Changed
+
 - **Sensor Module Architecture**: Extracted all sensor logic from `main.qml` into dedicated QML components under `contents/ui/sensors/`:
   - `CpuSensors.qml` — CPU usage monitoring
   - `MemorySensors.qml` — RAM usage monitoring
@@ -68,12 +95,14 @@ All notable changes to KVitals will be documented in this file.
 - **Reduced `main.qml`**: From ~700 lines to ~140 lines — now acts purely as an orchestrator.
 
 ### Notes
+
 - No user-facing or configuration changes. The widget behaves identically to v2.2.1.
 - This refactor improves maintainability and makes it easier to add new sensor types in the future.
 
 ## [2.2.1] - 2026-03-07
 
 ### Fixed
+
 - **Battery Detection Hotfix**: Replaced `SensorTreeModel` with a crash-free **Two-Stage Hybrid Detection** system (#14):
   - **Stage 1 (Silent Probe)**: Silently probes common battery paths (`BAT0`, `BAT1`, `BATT`, etc.) for instant detection without running any subprocesses.
   - **Stage 2 (Fallback)**: If no standard battery is found, falls back to a single `qdbus` query to list all sensors, completely avoiding `PlasmaCore.DataSource` file descriptor leaks. Includes a manual config fallback if `qdbus` is unavailable.
@@ -81,23 +110,27 @@ All notable changes to KVitals will be documented in this file.
 ## [2.2.0] - 2026-03-05
 
 ### Added
+
 - **Custom Metric Order**: Added a new configuration option to arrange metrics (CPU, RAM, GPU, etc.) individually in whatever order you prefer (#7).
 - **Dynamic Battery Detection**: Replaced hardcoded `BAT0`/`BAT1` sensors with dynamic `SensorTreeModel` discovery. The widget will now automatically find any battery your system has (BAT0, BATT, CMB0, macsmc-battery, etc.) (#14).
 
 ## [2.1.1] - 2026-03-03
 
 ### Fixed
+
 - Fixed a "Detected anchors on an item that is managed by a layout" QML warning spanning the journal log caused by a `MouseArea` anchoring inside a `RowLayout` (#13).
 
 ## [2.1.0] - 2026-03-01
 
 ### Added
+
 - **GPU Metrics Support**: Added VRAM usage and GPU temperature monitoring to the widget.
 - GPU data is retrieved natively using KDE KSysGuard sensors (`org.kde.ksysguard.sensors`).
 
 ## [2.0.0] - 2026-02-27
 
 ### Changed
+
 - **Major Architecture Overhaul**: Replaced the previous `sys-stats.sh` backend with native KDE KSysGuard sensors (`org.kde.ksysguard.sensors`).
 - Completely eliminates "file descriptor leak" crashes (Issue #8) and improves overall performance by relying directly on the `ksystemstats` D-Bus daemon instead of constantly spawning bash processes.
 - Automatic fallback for battery monitoring (BAT0 and BAT1) logic implemented directly in QML.
@@ -105,12 +138,14 @@ All notable changes to KVitals will be documented in this file.
 ## [1.4.1] - 2026-02-24
 
 ### Fixed
+
 - RAM usage showing empty on non-English locales — `free` translates its `Mem:` header based on locale, causing the parser to match nothing
 - Switched RAM data source from `free -b` to `/proc/meminfo` (locale-independent, faster, more accurate)
 
 ## [1.4.0] - 2026-02-22
 
 ### Added
+
 - **Display mode setting** — choose between Text, Icons, or Icons + Text for the panel
 - **Custom icon picker** — select icons from your installed theme for each metric (via KDE's native icon picker)
 - **Icon size slider** — adjust icon size (8–24px) when using icon mode
@@ -123,14 +158,17 @@ All notable changes to KVitals will be documented in this file.
 ## [1.3.0] - 2026-02-16
 
 ### Added
+
 - Power consumption tracking (via `/sys/class/power_supply/`) — contributed by [@Pijuli](https://github.com/Pijuli)
 
 ### Fixed
+
 - ShellCheck warnings from power consumption PR (SC2034, SC2155)
 
 ## [1.2.1] - 2026-02-16
 
 ### Fixed
+
 - AMD CPU temperature detection — added `k10temp`, `zenpower`, `zenergy`, `amdgpu` to thermal_zone and hwmon detection
 - lm-sensors fallback now matches AMD `Tccd1` label
 - Reordered temperature fallback tiers to prioritize CPU-specific sources over generic thermal zones
@@ -138,21 +176,25 @@ All notable changes to KVitals will be documented in this file.
 ## [1.2.0] - 2026-02-13
 
 ### Added
+
 - Auto-detect network interface via `ip route` with manual override in settings
 - Network interface selector in widget configuration
 
 ### Fixed
+
 - ShellCheck warnings (SC2010, SC2155)
 
 ## [1.1.0] - 2026-02-12
 
 ### Changed
+
 - Modularized `sys-stats.sh` into functions
 - Enhanced CPU temperature detection with 4-tier fallback (thermal_zone → hwmon → lm-sensors → generic)
 
 ## [1.0.0] - 2026-02-12
 
 ### Added
+
 - Initial release
 - CPU usage (delta-based from `/proc/stat`)
 - RAM usage (from `/proc/meminfo`)

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -55,6 +55,15 @@
         <entry name="batteryDevice" type="String">
             <default>auto</default>
         </entry>
+        <entry name="gpuSelection" type="String">
+            <default></default>
+        </entry>
+        <entry name="gpuDiscovered" type="String">
+            <default></default>
+        </entry>
+        <entry name="gpuLabels" type="String">
+            <default></default>
+        </entry>
         <entry name="displayMode" type="String">
             <default>text</default>
         </entry>

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -436,12 +436,20 @@ KCM.SimpleKCM {
                         checked: {
                             if (!cfg_gpuSelection || cfg_gpuSelection === "")
                                 return true;
+                            if (cfg_gpuSelection === "none")
+                                return false;
                             return cfg_gpuSelection.split(",").indexOf(modelData.id) >= 0;
                         }
                         onToggled: {
-                            var ids = (cfg_gpuSelection && cfg_gpuSelection !== "")
-                                ? cfg_gpuSelection.split(",").filter(function(s) { return s.length > 0; })
-                                : gpuSelectorRepeater.model.map(function(g) { return g.id; });
+                            // Expand current selection into an explicit id list
+                            var ids;
+                            if (!cfg_gpuSelection || cfg_gpuSelection === "") {
+                                ids = gpuSelectorRepeater.model.map(function(g) { return g.id; });
+                            } else if (cfg_gpuSelection === "none") {
+                                ids = [];
+                            } else {
+                                ids = cfg_gpuSelection.split(",").filter(function(s) { return s.length > 0; });
+                            }
                             if (checked) {
                                 if (ids.indexOf(modelData.id) < 0) ids.push(modelData.id);
                             } else {
@@ -449,7 +457,12 @@ KCM.SimpleKCM {
                             }
                             var allIds = gpuSelectorRepeater.model.map(function(g) { return g.id; });
                             var allSelected = allIds.every(function(id) { return ids.indexOf(id) >= 0; });
-                            cfg_gpuSelection = allSelected ? "" : ids.join(",");
+                            if (allSelected)
+                                cfg_gpuSelection = "";        // default: all discovered
+                            else if (ids.length === 0)
+                                cfg_gpuSelection = "none";    // explicit: nothing polled
+                            else
+                                cfg_gpuSelection = ids.join(",");
                         }
                     }
 

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -75,11 +75,11 @@ KCM.SimpleKCM {
         });
     }
 
-    // Parse "gpu0:Label A,gpu1:Label B" → { gpu0: "Label A", gpu1: "Label B" }
+    // Parse "gpu0:Label A|gpu1:Label B" → { gpu0: "Label A", gpu1: "Label B" }
     function parseGpuLabels(str) {
         var result = {};
         if (!str) return result;
-        var pairs = str.split(",");
+        var pairs = str.split("|");
         for (var i = 0; i < pairs.length; i++) {
             var sep = pairs[i].indexOf(":");
             if (sep > 0)
@@ -99,7 +99,7 @@ KCM.SimpleKCM {
         var parts = [];
         for (var id in labels)
             parts.push(id + ":" + labels[id]);
-        cfg_gpuLabels = parts.join(",");
+        cfg_gpuLabels = parts.join("|");
     }
     property string cfg_metricOrder: "cpu,ram,temp,gpu,bat,pwr,net"
     property bool cfg_mergeCpuTemp: false

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -4,6 +4,8 @@ import QtQuick.Layouts 1.0
 import org.kde.kirigami 2.5 as Kirigami
 import org.kde.kcmutils as KCM
 import org.kde.plasma.plasma5support as Plasma5Support
+import org.kde.ksysguard.sensors as Sensors
+import org.kde.kitemmodels as KItemModels
 
 KCM.SimpleKCM {
     id: metricsPage
@@ -23,7 +25,82 @@ KCM.SimpleKCM {
     property bool cfg_compactShowPower
     property bool cfg_compactShowNetwork
     property string cfg_networkInterface: "auto"
-    property string cfg_batteryDevice: "auto"
+    property string cfg_batteryDevice
+    property string cfg_gpuSelection: ""
+    property string cfg_gpuDiscovered
+    property string cfg_gpuLabels: ""
+
+    // Discover GPUs via SensorTreeModel — pure metadata, zero polling, no dGPU wakeup.
+    Sensors.SensorTreeModel {
+        id: cfgSensorTree
+    }
+
+    KItemModels.KDescendantsProxyModel {
+        id: cfgFlatSensors
+        model: cfgSensorTree
+    }
+
+    property var _liveDiscoveredGpus: []
+
+    function refreshConfigGpus() {
+        var found = [];
+        for (var row = 0; row < cfgFlatSensors.rowCount(); row++) {
+            var idx = cfgFlatSensors.index(row, 0);
+            var sensorId = cfgFlatSensors.data(idx, Sensors.SensorTreeModel.SensorId);
+            if (!sensorId || sensorId.length === 0) continue;
+            var match = sensorId.match(/^gpu\/(gpu\d+)\/usage$/);
+            if (!match) continue;
+            found.push({ id: match[1], name: "GPU " + (found.length + 1) });
+        }
+        if (JSON.stringify(found) !== JSON.stringify(_liveDiscoveredGpus))
+            _liveDiscoveredGpus = found;
+    }
+
+    Connections {
+        target: cfgFlatSensors
+        function onRowsInserted() { metricsPage.refreshConfigGpus(); }
+        function onRowsRemoved()  { metricsPage.refreshConfigGpus(); }
+        function onModelReset()   { metricsPage.refreshConfigGpus(); }
+        function onDataChanged()  { metricsPage.refreshConfigGpus(); }
+    }
+
+    // Use live results first; fall back to persisted cfg_gpuDiscovered if the
+    // sensor tree hasn't populated yet (e.g. very fast dialog open).
+    readonly property var discoveredGpus: {
+        if (_liveDiscoveredGpus.length > 0) return _liveDiscoveredGpus;
+        if (!cfg_gpuDiscovered) return [];
+        return cfg_gpuDiscovered.split(",").filter(function(s){ return s.indexOf(":") >= 0; }).map(function(s){
+            var parts = s.split(":");
+            return { id: parts[0], name: parts.slice(1).join(":") };
+        });
+    }
+
+    // Parse "gpu0:Label A,gpu1:Label B" → { gpu0: "Label A", gpu1: "Label B" }
+    function parseGpuLabels(str) {
+        var result = {};
+        if (!str) return result;
+        var pairs = str.split(",");
+        for (var i = 0; i < pairs.length; i++) {
+            var sep = pairs[i].indexOf(":");
+            if (sep > 0)
+                result[pairs[i].substring(0, sep)] = pairs[i].substring(sep + 1);
+        }
+        return result;
+    }
+
+    // Save a custom label for one GPU ID back into cfg_gpuLabels
+    function saveGpuLabel(gpuId, label) {
+        var labels = parseGpuLabels(cfg_gpuLabels);
+        var trimmed = (label || "").trim();
+        if (trimmed.length > 0)
+            labels[gpuId] = trimmed;
+        else
+            delete labels[gpuId];
+        var parts = [];
+        for (var id in labels)
+            parts.push(id + ":" + labels[id]);
+        cfg_gpuLabels = parts.join(",");
+    }
     property string cfg_metricOrder: "cpu,ram,temp,gpu,bat,pwr,net"
     property bool cfg_mergeCpuTemp: false
     property bool cfg_mergeCpuFreq: false
@@ -305,6 +382,98 @@ KCM.SimpleKCM {
             text: i18n("Empty value uses automatic detection.")
             opacity: 0.7
             visible: cfg_showBattery
+        }
+
+        // --- GPU selector ---
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: i18n("GPU Selection")
+            visible: cfg_showGpu
+        }
+
+        Label {
+            text: i18n("Select which GPUs to monitor. All selected GPUs are shown as separate metrics.")
+            opacity: 0.7
+            font.italic: true
+            visible: cfg_showGpu
+            wrapMode: Text.WordWrap
+            Layout.maximumWidth: 300
+        }
+
+        Label {
+            text: i18n("No GPUs detected yet — they appear once the widget loads.")
+            opacity: 0.7
+            font.italic: true
+            visible: cfg_showGpu && metricsPage.discoveredGpus.length === 0
+        }
+
+        Label {
+            text: i18n("On hybrid GPU laptops (e.g. Intel/AMD + NVIDIA), uncheck the discrete GPU to allow it to suspend when idle and save power.")
+            opacity: 0.7
+            font.italic: true
+            visible: cfg_showGpu && metricsPage.discoveredGpus.length > 1
+            wrapMode: Text.WordWrap
+            Layout.maximumWidth: 300
+        }
+
+        ColumnLayout {
+            visible: cfg_showGpu && metricsPage.discoveredGpus.length > 0
+            spacing: Kirigami.Units.smallSpacing
+
+            Repeater {
+                id: gpuSelectorRepeater
+                model: metricsPage.discoveredGpus
+
+                delegate: ColumnLayout {
+                    required property var modelData
+                    spacing: 2
+                    Layout.fillWidth: true
+
+                    CheckBox {
+                        // Show detected GPU name (e.g. "GPU 1") or user-defined custom label
+                        text: modelData.name
+                        checked: {
+                            if (!cfg_gpuSelection || cfg_gpuSelection === "")
+                                return true;
+                            return cfg_gpuSelection.split(",").indexOf(modelData.id) >= 0;
+                        }
+                        onToggled: {
+                            var ids = (cfg_gpuSelection && cfg_gpuSelection !== "")
+                                ? cfg_gpuSelection.split(",").filter(function(s) { return s.length > 0; })
+                                : gpuSelectorRepeater.model.map(function(g) { return g.id; });
+                            if (checked) {
+                                if (ids.indexOf(modelData.id) < 0) ids.push(modelData.id);
+                            } else {
+                                ids = ids.filter(function(id) { return id !== modelData.id; });
+                            }
+                            var allIds = gpuSelectorRepeater.model.map(function(g) { return g.id; });
+                            var allSelected = allIds.every(function(id) { return ids.indexOf(id) >= 0; });
+                            cfg_gpuSelection = allSelected ? "" : ids.join(",");
+                        }
+                    }
+
+                    // Custom label rename field
+                    RowLayout {
+                        Layout.fillWidth: true
+                        Layout.leftMargin: Kirigami.Units.gridUnit + Kirigami.Units.smallSpacing
+                        spacing: Kirigami.Units.smallSpacing
+
+                        Label {
+                            text: i18n("Label:")
+                            opacity: 0.8
+                        }
+
+                        TextField {
+                            Layout.fillWidth: true
+                            // Show current custom label or empty to let placeholder show
+                            text: metricsPage.parseGpuLabels(cfg_gpuLabels)[modelData.id] || ""
+                            placeholderText: modelData.name
+                            onTextEdited: metricsPage.saveGpuLabel(modelData.id, text)
+                        }
+                    }
+                }
+            }
         }
 
         Kirigami.Separator {

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -28,6 +28,8 @@ PlasmoidItem {
     property bool compactShowNetwork: Plasmoid.configuration.compactShowNetwork
     property string networkInterface: Plasmoid.configuration.networkInterface
     property string batteryDevice: Plasmoid.configuration.batteryDevice
+    property string gpuSelection: Plasmoid.configuration.gpuSelection
+    property string gpuLabels: Plasmoid.configuration.gpuLabels
     property string displayMode: Plasmoid.configuration.displayMode
     property string layoutType: Plasmoid.configuration.layoutType
     property bool mergeCpuTemp: Plasmoid.configuration.mergeCpuTemp
@@ -135,6 +137,8 @@ PlasmoidItem {
     GpuSensors {
         id: gpu
         updateInterval: root.updateInterval
+        gpuSelection: root.gpuSelection
+        gpuLabels: root.gpuLabels
     }
 
     BatterySensors {
@@ -186,7 +190,26 @@ PlasmoidItem {
                         color: root.tempColor
                     });
                 else if (key === "gpu" && root.showGpu && root.compactShowGpu && gpu.hasGpuData) {
-                    if (root.splitGpu) {
+                    var multiGpu = gpu.gpuDataList.length > 1;
+                    if (multiGpu) {
+                        // Show each GPU as a separate entry
+                        for (var g = 0; g < gpu.gpuDataList.length; g++) {
+                            var gd = gpu.gpuDataList[g];
+                            var label = (gd.name.length > 0 ? gd.name : gd.id) + ":";
+                            if (root.splitGpu) {
+                                if (gd.usage) items.push({icon: root.gpuIcon, label: label, value: gd.usage, color: root.gpuColor});
+                                if (gd.vram)  items.push({icon: root.gpuIcon, label: "VRAM:", value: gd.vram, color: root.baseTextColor});
+                                if (gd.temp)  items.push({icon: root.gpuIcon, label: "GTEMP:", value: gd.temp, color: root.gpuTempColor});
+                            } else {
+                                var segs2 = [];
+                                if (gd.usage) segs2.push({value: gd.usage, color: root.gpuColor});
+                                if (gd.vram)  segs2.push({value: gd.vram,  color: root.baseTextColor});
+                                if (gd.temp)  segs2.push({value: gd.temp,  color: root.gpuTempColor});
+                                if (segs2.length > 0)
+                                    items.push({icon: root.gpuIcon, label: label, segments: segs2, color: root.gpuColor});
+                            }
+                        }
+                    } else if (root.splitGpu) {
                         if (gpu.hasGpuUsageData)
                             items.push({icon: root.gpuIcon, label: "GPU:", value: gpu.gpuValue, color: root.gpuColor});
                         if (gpu.hasGpuVramData)
@@ -286,18 +309,28 @@ PlasmoidItem {
                         color: root.tempColor
                     });
                 else if (key === "gpu" && root.showGpu) {
-                    if (gpu.hasGpuUsageData) items.push({
-                        label: "GPU Usage", value: gpu.gpuValue,
-                        color: root.gpuColor
-                    });
-                    if (gpu.hasGpuVramData) items.push({
-                        label: "GPU VRAM", value: gpu.gpuRamValue,
-                        color: root.baseTextColor
-                    });
-                    if (gpu.hasGpuTempData) items.push({
-                        label: "GPU Temp", value: gpu.gpuTempValue,
-                        color: root.gpuTempColor
-                    });
+                    if (gpu.gpuDataList.length > 1) {
+                        for (var g = 0; g < gpu.gpuDataList.length; g++) {
+                            var gd = gpu.gpuDataList[g];
+                            var label = gd.name || gd.id;
+                            if (gd.usage) items.push({label: label + " Usage", value: gd.usage, color: root.gpuColor});
+                            if (gd.vram)  items.push({label: label + " VRAM",  value: gd.vram,  color: root.baseTextColor});
+                            if (gd.temp)  items.push({label: label + " Temp",  value: gd.temp,  color: root.gpuTempColor});
+                        }
+                    } else {
+                        if (gpu.hasGpuUsageData) items.push({
+                            label: "GPU Usage", value: gpu.gpuValue,
+                            color: root.gpuColor
+                        });
+                        if (gpu.hasGpuVramData) items.push({
+                            label: "GPU VRAM", value: gpu.gpuRamValue,
+                            color: root.baseTextColor
+                        });
+                        if (gpu.hasGpuTempData) items.push({
+                            label: "GPU Temp", value: gpu.gpuTempValue,
+                            color: root.gpuTempColor
+                        });
+                    }
                 } else if (key === "bat" && root.showBattery && battery.batValue)
                     items.push({
                         label: "Battery", value: battery.batValue,
@@ -331,9 +364,18 @@ PlasmoidItem {
             else if (key === "temp" && root.showTemp && temp.tempValue && temp.tempValue !== "--")
                 parts.push("TEMP: " + temp.tempValue);
             else if (key === "gpu" && root.showGpu && gpu.hasGpuData) {
-                if (gpu.hasGpuUsageData) parts.push("GPU: " + gpu.gpuValue);
-                if (gpu.hasGpuVramData) parts.push("VRAM: " + gpu.gpuRamValue);
-                if (gpu.hasGpuTempData) parts.push("GPU TEMP: " + gpu.gpuTempValue);
+                if (gpu.gpuDataList.length > 1) {
+                    for (var g = 0; g < gpu.gpuDataList.length; g++) {
+                        var gd = gpu.gpuDataList[g];
+                        var label = gd.name || gd.id;
+                        var vals = [gd.usage, gd.vram, gd.temp].filter(function(v) { return v; });
+                        if (vals.length > 0) parts.push(label + ": " + vals.join(" "));
+                    }
+                } else {
+                    if (gpu.hasGpuUsageData) parts.push("GPU: " + gpu.gpuValue);
+                    if (gpu.hasGpuVramData) parts.push("VRAM: " + gpu.gpuRamValue);
+                    if (gpu.hasGpuTempData) parts.push("GPU TEMP: " + gpu.gpuTempValue);
+                }
             } else if (key === "bat" && root.showBattery && battery.batValue)
                 parts.push("BAT: " + battery.batValue);
             else if (key === "pwr" && root.showPower && battery.powerValue)

--- a/contents/ui/sensors/GpuSensors.qml
+++ b/contents/ui/sensors/GpuSensors.qml
@@ -1,205 +1,198 @@
 import QtQuick
 import org.kde.ksysguard.sensors as Sensors
+import org.kde.kitemmodels as KItemModels
 
 Item {
     id: root
 
     property int updateInterval: 2000
 
-    readonly property real gpuUsageNumber: {
-        var aggregateUsage = Utils.firstReadyNumber([gpuUsageAllSensor], false);
-        if (!isNaN(aggregateUsage))
-            return aggregateUsage;
-        return Utils.maxReadyNumber([gpuUsage0Sensor, gpuUsage1Sensor, gpuUsage2Sensor, gpuUsage3Sensor], false);
+    // Comma-separated selected GPU IDs e.g. "gpu0,gpu1". Empty = all discovered.
+    property string gpuSelection: ""
+
+    // User-defined labels: "gpu0:My iGPU,gpu1:dGPU". Empty string = use default "GPU N" name.
+    property string gpuLabels: ""
+
+    // List of { id: "gpu0", name: "GPU 1" } derived from SensorTreeModel (no polling)
+    readonly property var discoveredGpus: _discovered
+    property var _discovered: []
+
+    // Aggregated display (single-GPU compat)
+    readonly property real gpuUsageNumber: _usageNum
+    readonly property real gpuTempNumber:  _tempNum
+    readonly property string gpuValue:     _usageStr
+    readonly property string gpuRamValue:  _vramStr
+    readonly property string gpuTempValue: _tempStr
+    readonly property string gpuDisplayValue: [_usageStr, _vramStr, _tempStr].filter(function(v){return v;}).join(" ")
+    readonly property bool hasGpuData:      gpuDisplayValue.length > 0
+    readonly property bool hasGpuUsageData: _usageStr.length > 0
+    readonly property bool hasGpuVramData:  _vramStr.length > 0
+    readonly property bool hasGpuTempData:  _tempStr.length > 0
+
+    // Per-GPU list for multi display: [{ id, name, usage, vram, temp, usageNumber, tempNumber }]
+    readonly property var gpuDataList: _dataList
+    property var _dataList: []
+
+    property real _usageNum: NaN
+    property real _tempNum:  NaN
+    property string _usageStr: ""
+    property string _vramStr:  ""
+    property string _tempStr:  ""
+
+    // -------------------------------------------------------------------------
+    // Step 1: Discover available GPUs via SensorTreeModel (metadata only, no polling)
+    // -------------------------------------------------------------------------
+
+    Sensors.SensorTreeModel {
+        id: sensorTree
     }
 
-    readonly property var gpuVramPair: {
-        return Utils.firstReadyVramPair([
-            { used: gpuVramUsedAllSensor, total: gpuVramTotalAllSensor },
-            { used: gpuVramUsedLegacySensor, total: gpuVramTotalLegacySensor },
-            { used: gpuVramUsed0Sensor, total: gpuVramTotal0Sensor },
-            { used: gpuVramUsed1Sensor, total: gpuVramTotal1Sensor },
-            { used: gpuVramUsed2Sensor, total: gpuVramTotal2Sensor },
-            { used: gpuVramUsed3Sensor, total: gpuVramTotal3Sensor }
-        ]);
+    KItemModels.KDescendantsProxyModel {
+        id: flatSensors
+        model: sensorTree
     }
 
-    readonly property real gpuTempNumber: {
-        var aggregateTemp = Utils.firstReadyNumber([gpuTempAllSensor], true);
-        if (!isNaN(aggregateTemp))
-            return aggregateTemp;
-        return Utils.maxReadyNumber([gpuTemp0Sensor, gpuTemp1Sensor, gpuTemp2Sensor, gpuTemp3Sensor], true);
+    // Parse "gpu0:Label A,gpu1:Label B" → { gpu0: "Label A", gpu1: "Label B" }
+    function parseGpuLabels(str) {
+        var result = {};
+        if (!str) return result;
+        var pairs = str.split(",");
+        for (var i = 0; i < pairs.length; i++) {
+            var sep = pairs[i].indexOf(":");
+            if (sep > 0)
+                result[pairs[i].substring(0, sep)] = pairs[i].substring(sep + 1);
+        }
+        return result;
     }
 
-    readonly property string gpuValue: {
-        if (isNaN(gpuUsageNumber))
-            return "";
-        return Math.round(gpuUsageNumber) + "%";
+    function refreshDiscovered() {
+        var found = [];
+        for (var row = 0; row < flatSensors.rowCount(); row++) {
+            var idx = flatSensors.index(row, 0);
+            var sensorId = flatSensors.data(idx, Sensors.SensorTreeModel.SensorId);
+            if (!sensorId || sensorId.length === 0) continue;
+            var match = sensorId.match(/^gpu\/(gpu\d+)\/usage$/);
+            if (!match) continue;
+            found.push({ id: match[1], name: "GPU " + (found.length + 1) });
+        }
+
+        if (JSON.stringify(found) !== JSON.stringify(_discovered)) {
+            _discovered = found;
+            if (typeof Plasmoid !== "undefined" && Plasmoid.configuration)
+                Plasmoid.configuration.gpuDiscovered = found.map(function(g){ return g.id + ":" + g.name; }).join(",");
+        }
     }
 
-    readonly property string gpuRamValue: {
-        if (!gpuVramPair)
-            return "";
-        return Utils.formatBytes(gpuVramPair.used) + "/" + Utils.formatBytes(gpuVramPair.total) + "G";
+    Connections {
+        target: flatSensors
+        function onRowsInserted()    { root.refreshDiscovered(); }
+        function onRowsRemoved()     { root.refreshDiscovered(); }
+        function onModelReset()      { root.refreshDiscovered(); }
+        function onDataChanged()     { root.refreshDiscovered(); }
     }
 
-    readonly property string gpuTempValue: {
-        if (isNaN(gpuTempNumber))
-            return "";
-        return Math.round(gpuTempNumber) + "°C";
+    // -------------------------------------------------------------------------
+    // Step 2: Compute active sensor IDs from user selection
+    // -------------------------------------------------------------------------
+
+    readonly property var _activeIds: {
+        if (!gpuSelection || gpuSelection === "")
+            return _discovered.map(function(g){ return g.id; });
+        return gpuSelection.split(",").map(function(s){ return s.trim(); }).filter(function(s){ return s.length > 0; });
     }
 
-    readonly property string gpuDisplayValue: {
-        var parts = [];
-        if (gpuValue)
-            parts.push(gpuValue);
-        if (gpuRamValue)
-            parts.push(gpuRamValue);
-        if (gpuTempValue)
-            parts.push(gpuTempValue);
-        return parts.join(" ");
+    readonly property var _activeSensorIds: {
+        var ids = [];
+        for (var i = 0; i < _activeIds.length; i++) {
+            var g = _activeIds[i];
+            ids.push("gpu/" + g + "/usage");
+            ids.push("gpu/" + g + "/usedVram");
+            ids.push("gpu/" + g + "/totalVram");
+            ids.push("gpu/" + g + "/temperature");
+        }
+        return ids;
     }
 
-    readonly property bool hasGpuData: gpuDisplayValue.length > 0
-    readonly property bool hasGpuUsageData: gpuValue.length > 0
-    readonly property bool hasGpuVramData: gpuRamValue.length > 0
-    readonly property bool hasGpuTempData: gpuTempValue.length > 0
+    // -------------------------------------------------------------------------
+    // Step 3: Single SensorDataModel — polls ONLY the selected sensors
+    // -------------------------------------------------------------------------
 
-    // --- Usage sensors ---
-
-    Sensors.Sensor {
-        id: gpuUsageAllSensor
-        sensorId: "gpu/all/usage"
+    Sensors.SensorDataModel {
+        id: gpuData
+        sensors: root._activeSensorIds
         updateRateLimit: root.updateInterval
+        enabled: root._activeSensorIds.length > 0
+
+        onDataChanged: root.aggregate()
+        onReadyChanged: { if (ready) root.aggregate(); }
     }
 
-    Sensors.Sensor {
-        id: gpuUsage0Sensor
-        sensorId: "gpu/gpu0/usage"
-        updateRateLimit: root.updateInterval
+    // -------------------------------------------------------------------------
+    // Step 4: Aggregate values — label resolution: custom label > default name > "GPU N"
+    // -------------------------------------------------------------------------
+
+    function _modelValue(sensorId) {
+        var col = gpuData.column(sensorId);
+        if (col < 0) return NaN;
+        var idx = gpuData.index(0, col);
+        if (!idx.valid) return NaN;
+        var val = gpuData.data(idx, Sensors.SensorDataModel.Value);
+        return (val === undefined || val === null) ? NaN : val;
     }
 
-    Sensors.Sensor {
-        id: gpuUsage1Sensor
-        sensorId: "gpu/gpu1/usage"
-        updateRateLimit: root.updateInterval
+    function aggregate() {
+        var ids = _activeIds;
+        var customLabels = parseGpuLabels(gpuLabels);
+        var newList = [];
+        var totalUsage = 0, usageCount = 0;
+        var totalVramUsed = 0, totalVramTotal = 0, hasVram = false;
+        var maxTemp = NaN;
+
+        for (var i = 0; i < ids.length; i++) {
+            var g = ids[i];
+
+            // Resolve display name: custom label > default name > fallback
+            var hwName = "GPU " + (i + 1);
+            for (var j = 0; j < _discovered.length; j++) {
+                if (_discovered[j].id === g) { hwName = _discovered[j].name; break; }
+            }
+            var name = customLabels[g] || hwName;
+
+            var uVal = _modelValue("gpu/" + g + "/usage");
+            var vuVal = _modelValue("gpu/" + g + "/usedVram");
+            var vtVal = _modelValue("gpu/" + g + "/totalVram");
+            var tVal  = _modelValue("gpu/" + g + "/temperature");
+
+            var uStr = isNaN(uVal) ? "" : Math.round(uVal) + "%";
+            var vStr = "";
+            if (!isNaN(vuVal) && !isNaN(vtVal) && vtVal > 0 && vuVal >= 0)
+                vStr = Utils.formatBytes(vuVal) + "/" + Utils.formatBytes(vtVal) + "G";
+            var tStr = (isNaN(tVal) || tVal <= 0) ? "" : Math.round(tVal) + "°C";
+
+            newList.push({ id: g, name: name,
+                           usage: uStr, vram: vStr, temp: tStr,
+                           usageNumber: isNaN(uVal) ? NaN : uVal,
+                           tempNumber:  isNaN(tVal) ? NaN : tVal });
+
+            if (!isNaN(uVal)) { totalUsage += uVal; usageCount++; }
+            if (!isNaN(vuVal) && !isNaN(vtVal) && vtVal > 0 && vuVal >= 0) {
+                totalVramUsed  += vuVal;
+                totalVramTotal += vtVal;
+                hasVram = true;
+            }
+            if (!isNaN(tVal) && (isNaN(maxTemp) || tVal > maxTemp)) maxTemp = tVal;
+        }
+
+        _dataList = newList;
+
+        _usageNum = usageCount > 0 ? totalUsage / usageCount : NaN;
+        _usageStr = usageCount > 0 ? Math.round(_usageNum) + "%" : "";
+        _vramStr  = (hasVram && totalVramTotal > 0)
+                    ? Utils.formatBytes(totalVramUsed) + "/" + Utils.formatBytes(totalVramTotal) + "G" : "";
+        _tempNum  = isNaN(maxTemp) ? NaN : maxTemp;
+        _tempStr  = isNaN(maxTemp) ? "" : Math.round(maxTemp) + "°C";
     }
 
-    Sensors.Sensor {
-        id: gpuUsage2Sensor
-        sensorId: "gpu/gpu2/usage"
-        updateRateLimit: root.updateInterval
-    }
-
-    Sensors.Sensor {
-        id: gpuUsage3Sensor
-        sensorId: "gpu/gpu3/usage"
-        updateRateLimit: root.updateInterval
-    }
-
-    // --- VRAM sensors ---
-
-    Sensors.Sensor {
-        id: gpuVramUsedAllSensor
-        sensorId: "gpu/all/usedVram"
-        updateRateLimit: root.updateInterval
-    }
-
-    Sensors.Sensor {
-        id: gpuVramTotalAllSensor
-        sensorId: "gpu/all/totalVram"
-        updateRateLimit: root.updateInterval
-    }
-
-    Sensors.Sensor {
-        id: gpuVramUsedLegacySensor
-        sensorId: "gpu/all/memory/used"
-        updateRateLimit: root.updateInterval
-    }
-
-    Sensors.Sensor {
-        id: gpuVramTotalLegacySensor
-        sensorId: "gpu/all/memory/total"
-        updateRateLimit: root.updateInterval
-    }
-
-    Sensors.Sensor {
-        id: gpuVramUsed0Sensor
-        sensorId: "gpu/gpu0/usedVram"
-        updateRateLimit: root.updateInterval
-    }
-
-    Sensors.Sensor {
-        id: gpuVramTotal0Sensor
-        sensorId: "gpu/gpu0/totalVram"
-        updateRateLimit: root.updateInterval
-    }
-
-    Sensors.Sensor {
-        id: gpuVramUsed1Sensor
-        sensorId: "gpu/gpu1/usedVram"
-        updateRateLimit: root.updateInterval
-    }
-
-    Sensors.Sensor {
-        id: gpuVramTotal1Sensor
-        sensorId: "gpu/gpu1/totalVram"
-        updateRateLimit: root.updateInterval
-    }
-
-    Sensors.Sensor {
-        id: gpuVramUsed2Sensor
-        sensorId: "gpu/gpu2/usedVram"
-        updateRateLimit: root.updateInterval
-    }
-
-    Sensors.Sensor {
-        id: gpuVramTotal2Sensor
-        sensorId: "gpu/gpu2/totalVram"
-        updateRateLimit: root.updateInterval
-    }
-
-    Sensors.Sensor {
-        id: gpuVramUsed3Sensor
-        sensorId: "gpu/gpu3/usedVram"
-        updateRateLimit: root.updateInterval
-    }
-
-    Sensors.Sensor {
-        id: gpuVramTotal3Sensor
-        sensorId: "gpu/gpu3/totalVram"
-        updateRateLimit: root.updateInterval
-    }
-
-    // --- Temperature sensors ---
-
-    Sensors.Sensor {
-        id: gpuTempAllSensor
-        sensorId: "gpu/all/temperature"
-        updateRateLimit: root.updateInterval
-    }
-
-    Sensors.Sensor {
-        id: gpuTemp0Sensor
-        sensorId: "gpu/gpu0/temperature"
-        updateRateLimit: root.updateInterval
-    }
-
-    Sensors.Sensor {
-        id: gpuTemp1Sensor
-        sensorId: "gpu/gpu1/temperature"
-        updateRateLimit: root.updateInterval
-    }
-
-    Sensors.Sensor {
-        id: gpuTemp2Sensor
-        sensorId: "gpu/gpu2/temperature"
-        updateRateLimit: root.updateInterval
-    }
-
-    Sensors.Sensor {
-        id: gpuTemp3Sensor
-        sensorId: "gpu/gpu3/temperature"
-        updateRateLimit: root.updateInterval
-    }
+    // Re-aggregate when labels change so panel updates immediately
+    onGpuLabelsChanged: aggregate()
 }

--- a/contents/ui/sensors/GpuSensors.qml
+++ b/contents/ui/sensors/GpuSensors.qml
@@ -96,8 +96,11 @@ Item {
     // -------------------------------------------------------------------------
 
     readonly property var _activeIds: {
+        // "" (default) → all discovered; "none" → user explicitly deselected everything
         if (!gpuSelection || gpuSelection === "")
             return _discovered.map(function(g){ return g.id; });
+        if (gpuSelection === "none")
+            return [];
         return gpuSelection.split(",").map(function(s){ return s.trim(); }).filter(function(s){ return s.length > 0; });
     }
 
@@ -140,18 +143,6 @@ Item {
         return (val === undefined || val === null) ? NaN : val;
     }
 
-    // Returns the sensor's Maximum metadata value, or 0 if unavailable.
-    // ksystemstats sets max=0 when a sensor exists in the tree but has no real
-    // hardware source (e.g. Intel iGPU temperature on this generation).
-    function _modelMax(sensorId) {
-        var col = gpuData.column(sensorId);
-        if (col < 0) return 0;
-        var idx = gpuData.index(0, col);
-        if (!idx.valid) return 0;
-        var val = gpuData.data(idx, Sensors.SensorDataModel.Maximum);
-        return (val === undefined || val === null) ? 0 : val;
-    }
-
     function aggregate() {
         var ids = _activeIds;
         var customLabels = parseGpuLabels(gpuLabels);
@@ -173,23 +164,20 @@ Item {
             var uVal  = _modelValue("gpu/" + g + "/usage");
             var vuVal = _modelValue("gpu/" + g + "/usedVram");
             var vtVal = _modelValue("gpu/" + g + "/totalVram");
-            var tSensorId = "gpu/" + g + "/temperature";
-            var tVal  = _modelValue(tSensorId);
-            var tMax  = _modelMax(tSensorId);  // 0 = sensor not available (no hwmon)
+            var tVal  = _modelValue("gpu/" + g + "/temperature");
 
             var uStr = isNaN(uVal) ? "" : Math.round(uVal) + "%";
             var vStr = "";
             if (!isNaN(vuVal) && !isNaN(vtVal) && vtVal > 0 && vuVal >= 0)
                 vStr = Utils.formatBytes(vuVal) + "/" + Utils.formatBytes(vtVal) + "G";
-            // Only show temperature when the sensor has a real hardware source (max > 0).
-            // Intel iGPU on laptops without hwmon reports value=0 and max=0; guard on
-            // max to avoid displaying "0°C" for an unavailable sensor.
-            var tStr = (isNaN(tVal) || tMax <= 0) ? "" : Math.round(tVal) + "°C";
+            // tVal === 0 is ksystemstats' null sentinel for iGPU: no hwmon node exists,
+            // so the driver reports exactly 0. No real GPU can be at or below 0°C.
+            var tStr = (isNaN(tVal) || tVal <= 0) ? "" : Math.round(tVal) + "°C";
 
             newList.push({ id: g, name: name,
                            usage: uStr, vram: vStr, temp: tStr,
                            usageNumber: isNaN(uVal) ? NaN : uVal,
-                           tempNumber:  isNaN(tVal) ? NaN : tVal });
+                           tempNumber:  (isNaN(tVal) || tVal <= 0) ? NaN : tVal });
 
             if (!isNaN(uVal)) { totalUsage += uVal; usageCount++; }
             if (!isNaN(vuVal) && !isNaN(vtVal) && vtVal > 0 && vuVal >= 0) {
@@ -197,7 +185,7 @@ Item {
                 totalVramTotal += vtVal;
                 hasVram = true;
             }
-            if (!isNaN(tVal) && (isNaN(maxTemp) || tVal > maxTemp)) maxTemp = tVal;
+            if (!isNaN(tVal) && tVal > 0 && (isNaN(maxTemp) || tVal > maxTemp)) maxTemp = tVal;
         }
 
         _dataList = newList;

--- a/contents/ui/sensors/GpuSensors.qml
+++ b/contents/ui/sensors/GpuSensors.qml
@@ -52,11 +52,11 @@ Item {
         model: sensorTree
     }
 
-    // Parse "gpu0:Label A,gpu1:Label B" → { gpu0: "Label A", gpu1: "Label B" }
+    // Parse "gpu0:Label A|gpu1:Label B" → { gpu0: "Label A", gpu1: "Label B" }
     function parseGpuLabels(str) {
         var result = {};
         if (!str) return result;
-        var pairs = str.split(",");
+        var pairs = str.split("|");
         for (var i = 0; i < pairs.length; i++) {
             var sep = pairs[i].indexOf(":");
             if (sep > 0)

--- a/contents/ui/sensors/GpuSensors.qml
+++ b/contents/ui/sensors/GpuSensors.qml
@@ -140,6 +140,18 @@ Item {
         return (val === undefined || val === null) ? NaN : val;
     }
 
+    // Returns the sensor's Maximum metadata value, or 0 if unavailable.
+    // ksystemstats sets max=0 when a sensor exists in the tree but has no real
+    // hardware source (e.g. Intel iGPU temperature on this generation).
+    function _modelMax(sensorId) {
+        var col = gpuData.column(sensorId);
+        if (col < 0) return 0;
+        var idx = gpuData.index(0, col);
+        if (!idx.valid) return 0;
+        var val = gpuData.data(idx, Sensors.SensorDataModel.Maximum);
+        return (val === undefined || val === null) ? 0 : val;
+    }
+
     function aggregate() {
         var ids = _activeIds;
         var customLabels = parseGpuLabels(gpuLabels);
@@ -158,16 +170,21 @@ Item {
             }
             var name = customLabels[g] || hwName;
 
-            var uVal = _modelValue("gpu/" + g + "/usage");
+            var uVal  = _modelValue("gpu/" + g + "/usage");
             var vuVal = _modelValue("gpu/" + g + "/usedVram");
             var vtVal = _modelValue("gpu/" + g + "/totalVram");
-            var tVal  = _modelValue("gpu/" + g + "/temperature");
+            var tSensorId = "gpu/" + g + "/temperature";
+            var tVal  = _modelValue(tSensorId);
+            var tMax  = _modelMax(tSensorId);  // 0 = sensor not available (no hwmon)
 
             var uStr = isNaN(uVal) ? "" : Math.round(uVal) + "%";
             var vStr = "";
             if (!isNaN(vuVal) && !isNaN(vtVal) && vtVal > 0 && vuVal >= 0)
                 vStr = Utils.formatBytes(vuVal) + "/" + Utils.formatBytes(vtVal) + "G";
-            var tStr = (isNaN(tVal) || tVal <= 0) ? "" : Math.round(tVal) + "°C";
+            // Only show temperature when the sensor has a real hardware source (max > 0).
+            // Intel iGPU on laptops without hwmon reports value=0 and max=0; guard on
+            // max to avoid displaying "0°C" for an unavailable sensor.
+            var tStr = (isNaN(tVal) || tMax <= 0) ? "" : Math.round(tVal) + "°C";
 
             newList.push({ id: g, name: name,
                            usage: uStr, vram: vStr, temp: tStr,
@@ -193,6 +210,7 @@ Item {
         _tempStr  = isNaN(maxTemp) ? "" : Math.round(maxTemp) + "°C";
     }
 
-    // Re-aggregate when labels change so panel updates immediately
-    onGpuLabelsChanged: aggregate()
+    // Re-aggregate when labels or selection change so panel updates immediately
+    onGpuLabelsChanged:    aggregate()
+    onGpuSelectionChanged: aggregate()
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,7 +48,7 @@ Right-click the widget → **Configure KVitals...** to open the settings dialog.
 | **CPU Usage**         | `CPU:`        | CPU utilization percentage                          |
 | **RAM Usage**         | `RAM:`        | Used/total memory                                   |
 | **CPU Temperature**   | `TEMP:`       | CPU temperature in °C                               |
-| **GPU Metrics**       | `GPU:`        | GPU usage, VRAM, and GPU temperature when available |
+| **GPU Metrics**       | `GPU:` / `<name>:` | GPU usage %, VRAM used/total, and GPU temperature. On multi-GPU systems, each selected GPU appears as a separate labeled entry. |
 | **Battery Status**    | `BAT:`        | Battery percentage                                  |
 | **Power Consumption** | `PWR:`        | Power draw in watts                                 |
 | **Network Speed**     | `NET:`        | Download/upload speeds                              |
@@ -85,6 +85,23 @@ single device.
 
 !!! note
     The manual interface list is populated dynamically from `/sys/class/net/`.
+
+### GPU Selection
+
+When the **GPU Metrics** metric is enabled, a **GPU Selection** section appears listing every GPU detected on your
+system. GPUs are discovered dynamically via the KDE sensor tree — no polling is required during discovery.
+
+| Control          | Description                                                                                   |
+|------------------|-----------------------------------------------------------------------------------------------|
+| **Checkbox**     | Enable or disable monitoring for each individual GPU                                          |
+| **Label field**  | Override the display name for a GPU. Leave empty to use the name reported by ksystemstats.   |
+
+**Label resolution order**: custom label → ksystemstats-provided name (e.g. `GPU 1`) → `GPU N` fallback.
+
+!!! tip "Hybrid GPU Laptops (Intel/AMD + NVIDIA)"
+    On hybrid setups using tools such as `supergfxctl` or `asusctl`, KVitals will only poll the GPUs whose
+    checkboxes are ticked. **Unchecking the discrete GPU** stops all polling for it, allowing it to enter its
+    suspended/power-save state when idle.
 
 ## Icons Tab
 

--- a/install.sh
+++ b/install.sh
@@ -4,21 +4,25 @@ set -euo pipefail
 PLASMOID_ID="org.kde.plasma.kvitals"
 SRC_DIR="$(cd "$(dirname "$0")" && pwd)"
 DEST_DIR="$HOME/.local/share/plasma/plasmoids/$PLASMOID_ID"
+KPACKAGE_DIR="$HOME/.local/share/kpackage/generic/$PLASMOID_ID"
 
 echo "Installing KVitals plasmoid..."
 
 # Remove old installation if present
-if [[ -d "$DEST_DIR" ]]; then
-    echo "  Removing previous installation..."
-    rm -rf "$DEST_DIR"
-fi
+for dir in "$DEST_DIR" "$KPACKAGE_DIR"; do
+    if [[ -d "$dir" ]] || [[ -L "$dir" ]]; then
+        echo "  Removing previous installation from $dir..."
+        rm -rf "$dir"
+    fi
+done
 
-# Create destination
+# Install to primary location
 mkdir -p "$DEST_DIR"
-
-# Copy everything
 cp -r "$SRC_DIR/metadata.json" "$DEST_DIR/"
 cp -r "$SRC_DIR/contents" "$DEST_DIR/"
+
+mkdir -p "$(dirname "$KPACKAGE_DIR")"
+ln -s "$DEST_DIR" "$KPACKAGE_DIR"
 
 
 echo ""
@@ -30,4 +34,4 @@ echo "  2. Click 'Add Widgets...'"
 echo "  3. Search for 'KVitals'"
 echo "  4. Drag it onto your panel"
 echo ""
-echo "To uninstall: rm -rf $DEST_DIR"
+echo "To uninstall: rm -rf $DEST_DIR $KPACKAGE_DIR"

--- a/metadata.json
+++ b/metadata.json
@@ -1,20 +1,20 @@
 {
-    "KPlugin": {
-        "Id": "org.kde.plasma.kvitals",
-        "Name": "KVitals",
-        "Description": "Live system vitals in the panel: CPU, RAM, Temp, Battery, Network",
-        "Icon": "utilities-system-monitor",
-        "Category": "System Information",
-        "Authors": [
-            {
-                "Name": "Yassine Amjad",
-                "Email": "yassine.amjad001@gmail.com"
-            }
-        ],
-        "Website": "https://github.com/yassine20011/kvitals",
-        "Version": "2.6.0",
-        "License": "GPL-3.0"
-    },
-    "KPackageStructure": "Plasma/Applet",
-    "X-Plasma-API-Minimum-Version": "6.0"
+  "KPlugin": {
+    "Id": "org.kde.plasma.kvitals",
+    "Name": "KVitals",
+    "Description": "Live system vitals in the panel: CPU, RAM, Temp, Battery, Network",
+    "Icon": "utilities-system-monitor",
+    "Category": "System Information",
+    "Authors": [
+      {
+        "Name": "Yassine Amjad",
+        "Email": "yassine.amjad001@gmail.com"
+      }
+    ],
+    "Website": "https://github.com/yassine20011/kvitals",
+    "Version": "2.7.0",
+    "License": "GPL-3.0"
+  },
+  "KPackageStructure": "Plasma/Applet",
+  "X-Plasma-API-Minimum-Version": "6.0"
 }


### PR DESCRIPTION
## Description

**Key Changes:**
- **Selective Polling**: Replaced individual probes with a single `SensorDataModel` that subscribes *only* to the GPUs the user has checked in the settings.
- **Multi-GPU UI**: On systems with multiple GPUs, each selected GPU is now listed individually as a separate metric in the compact panel, full popup, and tooltip.
- **Custom Labels**: Added a `gpuLabels` configuration string. Users can now assign custom display names (e.g., `iGPU`, `dGPU`, `RTX 3060`) to override the default `GPU 1` / `GPU 2` numbering in the UI.
- **Hybrid GPU Power Hint**: Added a contextual note in settings advising hybrid laptop users to uncheck their dGPU to allow it to suspend when idle.

*Note: If the dGPU remains active after unchecking it, it is likely due to an Xwayland application keeping it awake, which is outside KVitals' control.*

## Related Issue

Fixes #26 - [BUG] Unintended dGPU Wakeup
Closes #22 - Multi-GPU Support

## Testing

- [x] Tested on KDE Plasma 6.6.4
- [x] Distro: Fedora Linux 43
- [x] Widget installs cleanly with `install.sh.`
- [x] Widget displays correctly in the panel

## Screenshots

<img width="468" height="80" alt="image" src="https://github.com/user-attachments/assets/b1be156f-1ec2-4654-9b68-85de03bbe427" />

<br />

<img width="705" height="1020" alt="image" src="https://github.com/user-attachments/assets/a12dbd03-4952-460c-a2d2-458a54c4cfb9" />
