### PR TITLE
feat: add Disk I/O and temperature monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,43 +92,6 @@ rm -rf ~/.local/share/plasma/plasmoids/org.kde.plasma.kvitals
 
 Then restart Plasma: `plasmashell --replace &`
 
-## Project Structure
-
-```
-kvitals/
-├── metadata.json                   # Plasmoid metadata
-├── install.sh                      # Local install script
-├── install-remote.sh               # Remote install (curl/wget)
-├── CHANGELOG.md                    # Version history
-├── docs/                           # Documentation
-│   ├── installation.md
-│   ├── configuration.md
-│   ├── architecture.md
-│   ├── contributing.md
-│   └── troubleshooting.md
-└── contents/
-    ├── config/
-    │   ├── config.qml              # Tab registration
-    │   └── main.xml                # Config schema
-    └── ui/
-        ├── main.qml                # Widget orchestrator
-        ├── CompactView.qml         # Panel representation
-        ├── FullView.qml            # Popup representation
-        ├── configGeneral.qml       # General settings tab
-        ├── configMetrics.qml       # Metrics settings tab
-        ├── configIcons.qml         # Icons settings tab
-        ├── configColors.qml        # Colors settings tab
-        └── sensors/                # Sensor modules
-            ├── qmldir              # QML module definition
-            ├── CpuSensors.qml      # CPU usage
-            ├── MemorySensors.qml   # RAM usage
-            ├── TempSensors.qml     # CPU temperature
-            ├── GpuSensors.qml      # GPU usage, VRAM, temp
-            ├── BatterySensors.qml  # Battery & power
-            ├── NetworkSensors.qml  # Network speed
-            └── Utils.qml           # Shared formatting helpers
-```
-
 ## Documentation
 
 - [Installation](docs/installation.md)

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -28,6 +28,9 @@
         <entry name="showNetwork" type="Bool">
             <default>true</default>
         </entry>
+        <entry name="showDisk" type="Bool">
+            <default>false</default>
+        </entry>
         <entry name="compactShowCpu" type="Bool">
             <default>true</default>
         </entry>
@@ -48,6 +51,9 @@
         </entry>
         <entry name="compactShowNetwork" type="Bool">
             <default>true</default>
+        </entry>
+        <entry name="compactShowDisk" type="Bool">
+            <default>false</default>
         </entry>
         <entry name="networkInterface" type="String">
             <default>auto</default>
@@ -106,6 +112,9 @@
         <entry name="networkIcon" type="String">
             <default>network-wireless</default>
         </entry>
+        <entry name="diskIcon" type="String">
+            <default>drive-harddisk</default>
+        </entry>
         <entry name="fontFamily" type="String">
             <default>monospace</default>
         </entry>
@@ -116,7 +125,7 @@
             <default>false</default>
         </entry>
         <entry name="metricOrder" type="String">
-            <default>cpu,ram,temp,gpu,bat,pwr,net</default>
+            <default>cpu,ram,temp,gpu,bat,pwr,net,disk</default>
         </entry>
         <entry name="updateInterval" type="Int">
             <default>2000</default>
@@ -171,6 +180,12 @@
         </entry>
         <entry name="batteryCriticalThreshold" type="Int">
             <default>15</default>
+        </entry>
+        <entry name="diskTempWarningThreshold" type="Int">
+            <default>45</default>
+        </entry>
+        <entry name="diskTempCriticalThreshold" type="Int">
+            <default>60</default>
         </entry>
     </group>
 </kcfg>

--- a/contents/ui/configColors.qml
+++ b/contents/ui/configColors.qml
@@ -25,6 +25,8 @@ KCM.SimpleKCM {
     property alias cfg_gpuTempCriticalThreshold: gpuTempCritSlider.value
     property alias cfg_batteryWarningThreshold: batWarnSlider.value
     property alias cfg_batteryCriticalThreshold: batCritSlider.value
+    property alias cfg_diskTempWarningThreshold: diskTempWarnSlider.value
+    property alias cfg_diskTempCriticalThreshold: diskTempCritSlider.value
 
     readonly property string defaultWarningColor: "#e5a50a"
     readonly property string defaultCriticalColor: "#da4453"
@@ -364,6 +366,20 @@ KCM.SimpleKCM {
                 Label { text: Math.round(batCritSlider.value) + "%"; Layout.preferredWidth: 40 }
             }
             Rectangle { Layout.preferredWidth: 10; Layout.preferredHeight: 10; radius: 5; color: batWarnSlider.value <= batCritSlider.value ? cfg_criticalColor : "transparent" }
+
+            // --- Disk Temperature ---
+            Label { text: i18n("Disk Temp") }
+            RowLayout {
+                Layout.fillWidth: true
+                Slider { id: diskTempWarnSlider; from: 30; to: 80; stepSize: 5; value: 45; Layout.fillWidth: true }
+                Label { text: Math.round(diskTempWarnSlider.value) + "°C"; Layout.preferredWidth: 40 }
+            }
+            RowLayout {
+                Layout.fillWidth: true
+                Slider { id: diskTempCritSlider; from: 30; to: 80; stepSize: 5; value: 60; Layout.fillWidth: true }
+                Label { text: Math.round(diskTempCritSlider.value) + "°C"; Layout.preferredWidth: 40 }
+            }
+            Rectangle { Layout.preferredWidth: 10; Layout.preferredHeight: 10; radius: 5; color: diskTempWarnSlider.value >= diskTempCritSlider.value ? cfg_criticalColor : "transparent" }
         }
 
         Label {
@@ -399,6 +415,7 @@ KCM.SimpleKCM {
                 gpuWarnSlider.value = 70;  gpuCritSlider.value = 90
                 gpuTempWarnSlider.value = 60; gpuTempCritSlider.value = 85
                 batWarnSlider.value = 30;  batCritSlider.value = 15
+                diskTempWarnSlider.value = 45; diskTempCritSlider.value = 60
             }
         }
     }

--- a/contents/ui/configIcons.qml
+++ b/contents/ui/configIcons.qml
@@ -15,6 +15,7 @@ KCM.SimpleKCM {
     property string cfg_batteryIcon: "battery-good"
     property string cfg_powerIcon: "battery-charging-60"
     property string cfg_networkIcon: "network-wireless"
+    property string cfg_diskIcon: "drive-harddisk"
 
     KIconThemes.IconDialog {
         id: cpuIconDialog
@@ -43,6 +44,10 @@ KCM.SimpleKCM {
     KIconThemes.IconDialog {
         id: networkIconDialog
         onIconNameChanged: if (iconName) cfg_networkIcon = iconName
+    }
+    KIconThemes.IconDialog {
+        id: diskIconDialog
+        onIconNameChanged: if (iconName) cfg_diskIcon = iconName
     }
 
     Kirigami.FormLayout {
@@ -89,6 +94,12 @@ KCM.SimpleKCM {
             Button { text: i18n("Change..."); onClicked: networkIconDialog.open(); icon.name: "document-edit" }
         }
 
+        RowLayout {
+            Kirigami.FormData.label: i18n("Disk:")
+            Kirigami.Icon { source: cfg_diskIcon; isMask: true; Layout.preferredWidth: 22; Layout.preferredHeight: 22 }
+            Button { text: i18n("Change..."); onClicked: diskIconDialog.open(); icon.name: "document-edit" }
+        }
+
         Button {
             icon.name: "edit-undo"
             text: i18n("Reset to defaults")
@@ -101,6 +112,7 @@ KCM.SimpleKCM {
                 cfg_batteryIcon = "battery-good";
                 cfg_powerIcon = "battery-charging-60";
                 cfg_networkIcon = "network-wireless";
+                cfg_diskIcon = "drive-harddisk";
             }
         }
     }

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -17,6 +17,7 @@ KCM.SimpleKCM {
     property bool cfg_showBattery
     property bool cfg_showPower
     property bool cfg_showNetwork
+    property bool cfg_showDisk
     property bool cfg_compactShowCpu
     property bool cfg_compactShowRam
     property bool cfg_compactShowTemp
@@ -24,6 +25,7 @@ KCM.SimpleKCM {
     property bool cfg_compactShowBattery
     property bool cfg_compactShowPower
     property bool cfg_compactShowNetwork
+    property bool cfg_compactShowDisk
     property string cfg_networkInterface: "auto"
     property string cfg_batteryDevice
     property string cfg_gpuSelection: ""
@@ -110,7 +112,7 @@ KCM.SimpleKCM {
 
     property var ifaceList: ["auto"]
 
-    readonly property var allKeys: ["cpu", "ram", "temp", "gpu", "bat", "pwr", "net"]
+    readonly property var allKeys: ["cpu", "ram", "temp", "gpu", "bat", "pwr", "net", "disk"]
 
     readonly property var metricLabels: ({
         "cpu": i18n("CPU Usage"),
@@ -119,7 +121,8 @@ KCM.SimpleKCM {
         "gpu": i18n("GPU Metrics"),
         "bat": i18n("Battery Status"),
         "pwr": i18n("Power Consumption"),
-        "net": i18n("Network Speed")
+        "net": i18n("Network Speed"),
+        "disk": i18n("Disk I/O & Temp")
     })
 
     property var currentOrder: {
@@ -153,6 +156,8 @@ KCM.SimpleKCM {
                 return cfg_showPower;
             case "net":
                 return cfg_showNetwork;
+            case "disk":
+                return cfg_showDisk;
         }
         return false;
     }
@@ -173,6 +178,8 @@ KCM.SimpleKCM {
                 return cfg_compactShowPower;
             case "net":
                 return cfg_compactShowNetwork;
+            case "disk":
+                return cfg_compactShowDisk;
         }
         return false;
     }
@@ -199,6 +206,9 @@ KCM.SimpleKCM {
                 break;
             case "net":
                 cfg_showNetwork = val;
+                break;
+            case "disk":
+                cfg_showDisk = val;
                 break;
         }
         // Reset merge toggles when a prerequisite metric is disabled
@@ -234,6 +244,9 @@ KCM.SimpleKCM {
                 break;
             case "net":
                 cfg_compactShowNetwork = val;
+                break;
+            case "disk":
+                cfg_compactShowDisk = val;
                 break;
         }
     }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -56,7 +56,7 @@ PlasmoidItem {
     property bool useIcons: displayMode === "icons" || displayMode === "icons+text"
     property bool useText: displayMode === "text" || displayMode === "icons+text"
 
-    property string metricOrder: Plasmoid.configuration.metricOrder || "cpu,ram,temp,gpu,bat,pwr,net"
+    property string metricOrder: Plasmoid.configuration.metricOrder || "cpu,ram,temp,gpu,bat,pwr,net,disk"
     property var orderedKeys: metricOrder.split(",").map(function (k) {
         return k.trim();
     })
@@ -166,6 +166,7 @@ PlasmoidItem {
     DiskSensors {
         id: disk
         updateInterval: root.updateInterval
+        enabled: root.showDisk
     }
 
     // --- Representations ---

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -19,6 +19,7 @@ PlasmoidItem {
     property bool showBattery: Plasmoid.configuration.showBattery
     property bool showPower: Plasmoid.configuration.showPower
     property bool showNetwork: Plasmoid.configuration.showNetwork
+    property bool showDisk: Plasmoid.configuration.showDisk
     property bool compactShowCpu: Plasmoid.configuration.compactShowCpu
     property bool compactShowRam: Plasmoid.configuration.compactShowRam
     property bool compactShowTemp: Plasmoid.configuration.compactShowTemp
@@ -26,6 +27,7 @@ PlasmoidItem {
     property bool compactShowBattery: Plasmoid.configuration.compactShowBattery
     property bool compactShowPower: Plasmoid.configuration.compactShowPower
     property bool compactShowNetwork: Plasmoid.configuration.compactShowNetwork
+    property bool compactShowDisk: Plasmoid.configuration.compactShowDisk
     property string networkInterface: Plasmoid.configuration.networkInterface
     property string batteryDevice: Plasmoid.configuration.batteryDevice
     property string gpuSelection: Plasmoid.configuration.gpuSelection
@@ -45,6 +47,7 @@ PlasmoidItem {
     property string batteryIcon: Plasmoid.configuration.batteryIcon
     property string powerIcon: Plasmoid.configuration.powerIcon
     property string networkIcon: Plasmoid.configuration.networkIcon
+    property string diskIcon: Plasmoid.configuration.diskIcon
     property string fontFamily: Plasmoid.configuration.fontFamily
     property int fontSize: Plasmoid.configuration.fontSize
     property bool fontBold: Plasmoid.configuration.fontBold
@@ -80,6 +83,8 @@ PlasmoidItem {
     property int gpuTempCriticalThreshold: Plasmoid.configuration.gpuTempCriticalThreshold
     property int batteryWarningThreshold: Plasmoid.configuration.batteryWarningThreshold
     property int batteryCriticalThreshold: Plasmoid.configuration.batteryCriticalThreshold
+    property int diskTempWarningThreshold: Plasmoid.configuration.diskTempWarningThreshold
+    property int diskTempCriticalThreshold: Plasmoid.configuration.diskTempCriticalThreshold
 
     // --- Computed base text color ---
 
@@ -117,6 +122,11 @@ PlasmoidItem {
             warningColor, criticalColor, baseTextColor, true)
         : baseTextColor
 
+    property color diskTempColor: enableThresholdColors
+        ? Utils.resolveColor(disk.diskTempNumber, diskTempWarningThreshold, diskTempCriticalThreshold,
+            warningColor, criticalColor, baseTextColor, false)
+        : baseTextColor
+
     // --- Sensor components ---
 
     CpuSensors {
@@ -151,6 +161,11 @@ PlasmoidItem {
         id: network
         updateInterval: root.updateInterval
         networkInterface: root.networkInterface
+    }
+
+    DiskSensors {
+        id: disk
+        updateInterval: root.updateInterval
     }
 
     // --- Representations ---
@@ -267,6 +282,13 @@ PlasmoidItem {
                         value: "↓" + network.netDownValue + " ↑" + network.netUpValue,
                         color: root.baseTextColor
                     });
+                else if (key === "disk" && root.showDisk && root.compactShowDisk) {
+                    var diskSegs = [{value: "↓" + disk.diskReadValue, color: root.baseTextColor},
+                                    {value: "↑" + disk.diskWriteValue, color: root.baseTextColor}];
+                    if (disk.diskTempValue)
+                        diskSegs.push({value: disk.diskTempValue, color: root.diskTempColor});
+                    items.push({icon: root.diskIcon, label: "DSK:", segments: diskSegs, color: root.baseTextColor});
+                }
             }
             return items;
         }
@@ -345,6 +367,12 @@ PlasmoidItem {
                     items.push({label: "Network ↓", value: network.netDownValue, color: root.baseTextColor});
                     items.push({label: "Network ↑", value: network.netUpValue, color: root.baseTextColor});
                 }
+                else if (key === "disk" && root.showDisk) {
+                    items.push({label: "Disk Read",  value: disk.diskReadValue,  color: root.baseTextColor});
+                    items.push({label: "Disk Write", value: disk.diskWriteValue, color: root.baseTextColor});
+                    if (disk.diskTempValue)
+                        items.push({label: "Disk Temp", value: disk.diskTempValue, color: root.diskTempColor});
+                }
             }
             return items;
         }
@@ -382,6 +410,11 @@ PlasmoidItem {
                 parts.push("PWR: " + battery.powerValue);
             else if (key === "net" && root.showNetwork)
                 parts.push("NET: ↓" + network.netDownValue + " ↑" + network.netUpValue);
+            else if (key === "disk" && root.showDisk) {
+                var dParts = ["↓" + disk.diskReadValue, "↑" + disk.diskWriteValue];
+                if (disk.diskTempValue) dParts.push(disk.diskTempValue);
+                parts.push("DSK: " + dParts.join(" "));
+            }
         }
         return parts.join("\n");
     }

--- a/contents/ui/sensors/DiskSensors.qml
+++ b/contents/ui/sensors/DiskSensors.qml
@@ -1,0 +1,85 @@
+import QtQuick
+import org.kde.ksysguard.sensors as Sensors
+import org.kde.kitemmodels as KItemModels
+
+Item {
+    id: root
+
+    property int updateInterval: 2000
+
+    readonly property string diskReadValue:  Utils.formatRate(diskReadSensor.status  === Sensors.Sensor.Ready ? diskReadSensor.value  : NaN)
+    readonly property string diskWriteValue: Utils.formatRate(diskWriteSensor.status === Sensors.Sensor.Ready ? diskWriteSensor.value : NaN)
+
+    // Highest temperature found across all discovered drive temp sensors (°C)
+    readonly property real   diskTempNumber: _diskTempNum
+    readonly property string diskTempValue:  isNaN(_diskTempNum) ? "" : Math.round(_diskTempNum) + "°C"
+
+    property real _diskTempNum: NaN
+
+    // I/O sensors 
+    Sensors.Sensor {
+        id: diskReadSensor
+        sensorId: "disk/all/read"
+        updateRateLimit: root.updateInterval
+    }
+
+    Sensors.Sensor {
+        id: diskWriteSensor
+        sensorId: "disk/all/write"
+        updateRateLimit: root.updateInterval
+    }
+
+    // Matches lmsensors chips that are NVMe (nvme-pci-*) or SATA drivetemp
+    // (drivetemp-scsi-*) and picks temp1 (Composite) or temp2 (secondary sensor)
+
+    Sensors.SensorTreeModel { id: sensorTree }
+
+    KItemModels.KDescendantsProxyModel {
+        id: flatSensors
+        model: sensorTree
+    }
+
+    property var _tempSensorIds: []
+
+    function _refreshTempSensors() {
+        var found = [];
+        for (var row = 0; row < flatSensors.rowCount(); row++) {
+            var idx = flatSensors.index(row, 0);
+            var sid = flatSensors.data(idx, Sensors.SensorTreeModel.SensorId);
+            if (!sid) continue;
+            if (/^lmsensors\/(nvme-pci-[^/]+|drivetemp-scsi-[^/]+)\/temp[12]$/.test(sid))
+                found.push(sid);
+        }
+        if (JSON.stringify(found) !== JSON.stringify(_tempSensorIds))
+            _tempSensorIds = found;
+    }
+
+    Connections {
+        target: flatSensors
+        function onRowsInserted() { root._refreshTempSensors(); }
+        function onRowsRemoved()  { root._refreshTempSensors(); }
+        function onModelReset()   { root._refreshTempSensors(); }
+    }
+
+    // Poll discovered temp sensors
+    Sensors.SensorDataModel {
+        id: tempData
+        sensors: root._tempSensorIds
+        updateRateLimit: root.updateInterval
+        enabled: root._tempSensorIds.length > 0
+        onDataChanged: root._aggregateTemp()
+        onReadyChanged: { if (ready) root._aggregateTemp(); }
+    }
+
+    function _aggregateTemp() {
+        var max = NaN;
+        for (var i = 0; i < _tempSensorIds.length; i++) {
+            var col = tempData.column(_tempSensorIds[i]);
+            if (col < 0) continue;
+            var val = tempData.data(tempData.index(0, col), Sensors.SensorDataModel.Value);
+            if (typeof val !== "number" || isNaN(val) || val <= 0) continue;
+            if (isNaN(max) || val > max) max = val;
+        }
+        _diskTempNum = max;
+    }
+}

--- a/contents/ui/sensors/DiskSensors.qml
+++ b/contents/ui/sensors/DiskSensors.qml
@@ -6,6 +6,7 @@ Item {
     id: root
 
     property int updateInterval: 2000
+    property bool enabled: true
 
     readonly property string diskReadValue:  Utils.formatRate(diskReadSensor.status  === Sensors.Sensor.Ready ? diskReadSensor.value  : NaN)
     readonly property string diskWriteValue: Utils.formatRate(diskWriteSensor.status === Sensors.Sensor.Ready ? diskWriteSensor.value : NaN)
@@ -21,12 +22,14 @@ Item {
         id: diskReadSensor
         sensorId: "disk/all/read"
         updateRateLimit: root.updateInterval
+        enabled: root.enabled
     }
 
     Sensors.Sensor {
         id: diskWriteSensor
         sensorId: "disk/all/write"
         updateRateLimit: root.updateInterval
+        enabled: root.enabled
     }
 
     // Matches lmsensors chips that are NVMe (nvme-pci-*) or SATA drivetemp
@@ -60,6 +63,8 @@ Item {
         function onRowsRemoved()  { root._refreshTempSensors(); }
         function onModelReset()   { root._refreshTempSensors(); }
     }
+
+    Component.onCompleted: _refreshTempSensors()
 
     // Poll discovered temp sensors
     Sensors.SensorDataModel {

--- a/contents/ui/sensors/GpuSensors.qml
+++ b/contents/ui/sensors/GpuSensors.qml
@@ -91,6 +91,8 @@ Item {
         function onDataChanged()     { root.refreshDiscovered(); }
     }
 
+    Component.onCompleted: refreshDiscovered()
+
     // -------------------------------------------------------------------------
     // Step 2: Compute active sensor IDs from user selection
     // -------------------------------------------------------------------------

--- a/contents/ui/sensors/qmldir
+++ b/contents/ui/sensors/qmldir
@@ -6,3 +6,4 @@ TempSensors 1.0 TempSensors.qml
 GpuSensors 1.0 GpuSensors.qml
 BatterySensors 1.0 BatterySensors.qml
 NetworkSensors 1.0 NetworkSensors.qml
+DiskSensors 1.0 DiskSensors.qml


### PR DESCRIPTION
## Description

- Add DiskSensors.qml: polls disk/all/read and disk/all/write for aggregate I/O rates; discovers NVMe `lmsensors/nvme-pci-*` and SATA drivetemp `lmsensors/drivetemp-scsi-*` temperature sensors via SensorTreeModel and reports the highest temp found
- Add showDisk / compactShowDisk config keys (default: false)
- Add diskIcon config key (default: drive-harddisk)
- Add diskTempWarningThreshold (45°C) / diskTempCriticalThreshold (60°C)
- Wire disk metric into compact panel, full popup, and tooltip
- Add disk toggle and ordering to configMetrics
- Add disk temp threshold sliders to configColors
- Add disk icon picker to configIcons
- Register DiskSensors in sensors/qmldir

Disk temperature requires the drivetemp kernel module for SATA drives. NVMe temperature works out of the box. If no temp sensors are found, the temperature field is silently omitted.

## Testing

- [x] Tested on KDE Plasma 6.6.4
- [x] Distro: Fedora Linux 43
- [x] Widget installs cleanly with `install.sh.`
- [x] Widget displays correctly in the panel

## Screenshots

<img width="565" height="31" alt="image" src="https://github.com/user-attachments/assets/a36522c3-a840-4f37-9b77-1ad1f137f0fa" />

<img width="437" height="68" alt="image" src="https://github.com/user-attachments/assets/d1b905c0-0609-4796-8ff4-596eaefa2009" />
