### PR TITLE
feat: add global unit preferences for temperature and data rates

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -187,5 +187,11 @@
         <entry name="diskTempCriticalThreshold" type="Int">
             <default>60</default>
         </entry>
+        <entry name="tempUnit" type="String">
+            <default>C</default>
+        </entry>
+        <entry name="networkUnit" type="String">
+            <default>bytes</default>
+        </entry>
     </group>
 </kcfg>

--- a/contents/ui/configColors.qml
+++ b/contents/ui/configColors.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts 1.0
 import Qt.labs.platform 1.0 as Platform
 import org.kde.kirigami 2.5 as Kirigami
 import org.kde.kcmutils as KCM
+import "./sensors"
 
 KCM.SimpleKCM {
     id: colorsPage
@@ -32,13 +33,6 @@ KCM.SimpleKCM {
     readonly property string defaultCriticalColor: "#da4453"
 
     property string cfg_tempUnit: "C"
-
-    // Thresholds are stored in °C; this converts the label only — comparison stays in °C
-    function formatThresholdTemp(celsius) {
-        if (cfg_tempUnit === "F")
-            return Math.round(celsius * 9 / 5 + 32) + "°F";
-        return Math.round(celsius) + "°C";
-    }
 
     function isRgbHex(value) {
         return /^#[0-9A-Fa-f]{6}$/.test(value)
@@ -311,12 +305,12 @@ KCM.SimpleKCM {
             RowLayout {
                 Layout.fillWidth: true
                 Slider { id: tempWarnSlider; from: 30; to: 110; stepSize: 5; value: 60; Layout.fillWidth: true }
-                Label { text: colorsPage.formatThresholdTemp(tempWarnSlider.value); Layout.preferredWidth: 40 }
+                Label { text: Utils.formatTemp(tempWarnSlider.value, cfg_tempUnit); Layout.preferredWidth: 40 }
             }
             RowLayout {
                 Layout.fillWidth: true
                 Slider { id: tempCritSlider; from: 30; to: 110; stepSize: 5; value: 85; Layout.fillWidth: true }
-                Label { text: colorsPage.formatThresholdTemp(tempCritSlider.value); Layout.preferredWidth: 40 }
+                Label { text: Utils.formatTemp(tempCritSlider.value, cfg_tempUnit); Layout.preferredWidth: 40 }
             }
             Rectangle { Layout.preferredWidth: 10; Layout.preferredHeight: 10; radius: 5; color: tempWarnSlider.value >= tempCritSlider.value ? cfg_criticalColor : "transparent" }
 
@@ -353,12 +347,12 @@ KCM.SimpleKCM {
             RowLayout {
                 Layout.fillWidth: true
                 Slider { id: gpuTempWarnSlider; from: 30; to: 110; stepSize: 5; value: 60; Layout.fillWidth: true }
-                Label { text: colorsPage.formatThresholdTemp(gpuTempWarnSlider.value); Layout.preferredWidth: 40 }
+                Label { text: Utils.formatTemp(gpuTempWarnSlider.value, cfg_tempUnit); Layout.preferredWidth: 40 }
             }
             RowLayout {
                 Layout.fillWidth: true
                 Slider { id: gpuTempCritSlider; from: 30; to: 110; stepSize: 5; value: 85; Layout.fillWidth: true }
-                Label { text: colorsPage.formatThresholdTemp(gpuTempCritSlider.value); Layout.preferredWidth: 40 }
+                Label { text: Utils.formatTemp(gpuTempCritSlider.value, cfg_tempUnit); Layout.preferredWidth: 40 }
             }
             Rectangle { Layout.preferredWidth: 10; Layout.preferredHeight: 10; radius: 5; color: gpuTempWarnSlider.value >= gpuTempCritSlider.value ? cfg_criticalColor : "transparent" }
 
@@ -381,12 +375,12 @@ KCM.SimpleKCM {
             RowLayout {
                 Layout.fillWidth: true
                 Slider { id: diskTempWarnSlider; from: 30; to: 80; stepSize: 5; value: 45; Layout.fillWidth: true }
-                Label { text: colorsPage.formatThresholdTemp(diskTempWarnSlider.value); Layout.preferredWidth: 40 }
+                Label { text: Utils.formatTemp(diskTempWarnSlider.value, cfg_tempUnit); Layout.preferredWidth: 40 }
             }
             RowLayout {
                 Layout.fillWidth: true
                 Slider { id: diskTempCritSlider; from: 30; to: 80; stepSize: 5; value: 60; Layout.fillWidth: true }
-                Label { text: colorsPage.formatThresholdTemp(diskTempCritSlider.value); Layout.preferredWidth: 40 }
+                Label { text: Utils.formatTemp(diskTempCritSlider.value, cfg_tempUnit); Layout.preferredWidth: 40 }
             }
             Rectangle { Layout.preferredWidth: 10; Layout.preferredHeight: 10; radius: 5; color: diskTempWarnSlider.value >= diskTempCritSlider.value ? cfg_criticalColor : "transparent" }
         }

--- a/contents/ui/configColors.qml
+++ b/contents/ui/configColors.qml
@@ -31,6 +31,15 @@ KCM.SimpleKCM {
     readonly property string defaultWarningColor: "#e5a50a"
     readonly property string defaultCriticalColor: "#da4453"
 
+    property string cfg_tempUnit: "C"
+
+    // Thresholds are stored in °C; this converts the label only — comparison stays in °C
+    function formatThresholdTemp(celsius) {
+        if (cfg_tempUnit === "F")
+            return Math.round(celsius * 9 / 5 + 32) + "°F";
+        return Math.round(celsius) + "°C";
+    }
+
     function isRgbHex(value) {
         return /^#[0-9A-Fa-f]{6}$/.test(value)
     }
@@ -302,12 +311,12 @@ KCM.SimpleKCM {
             RowLayout {
                 Layout.fillWidth: true
                 Slider { id: tempWarnSlider; from: 30; to: 110; stepSize: 5; value: 60; Layout.fillWidth: true }
-                Label { text: Math.round(tempWarnSlider.value) + "°C"; Layout.preferredWidth: 40 }
+                Label { text: colorsPage.formatThresholdTemp(tempWarnSlider.value); Layout.preferredWidth: 40 }
             }
             RowLayout {
                 Layout.fillWidth: true
                 Slider { id: tempCritSlider; from: 30; to: 110; stepSize: 5; value: 85; Layout.fillWidth: true }
-                Label { text: Math.round(tempCritSlider.value) + "°C"; Layout.preferredWidth: 40 }
+                Label { text: colorsPage.formatThresholdTemp(tempCritSlider.value); Layout.preferredWidth: 40 }
             }
             Rectangle { Layout.preferredWidth: 10; Layout.preferredHeight: 10; radius: 5; color: tempWarnSlider.value >= tempCritSlider.value ? cfg_criticalColor : "transparent" }
 
@@ -344,12 +353,12 @@ KCM.SimpleKCM {
             RowLayout {
                 Layout.fillWidth: true
                 Slider { id: gpuTempWarnSlider; from: 30; to: 110; stepSize: 5; value: 60; Layout.fillWidth: true }
-                Label { text: Math.round(gpuTempWarnSlider.value) + "°C"; Layout.preferredWidth: 40 }
+                Label { text: colorsPage.formatThresholdTemp(gpuTempWarnSlider.value); Layout.preferredWidth: 40 }
             }
             RowLayout {
                 Layout.fillWidth: true
                 Slider { id: gpuTempCritSlider; from: 30; to: 110; stepSize: 5; value: 85; Layout.fillWidth: true }
-                Label { text: Math.round(gpuTempCritSlider.value) + "°C"; Layout.preferredWidth: 40 }
+                Label { text: colorsPage.formatThresholdTemp(gpuTempCritSlider.value); Layout.preferredWidth: 40 }
             }
             Rectangle { Layout.preferredWidth: 10; Layout.preferredHeight: 10; radius: 5; color: gpuTempWarnSlider.value >= gpuTempCritSlider.value ? cfg_criticalColor : "transparent" }
 
@@ -372,12 +381,12 @@ KCM.SimpleKCM {
             RowLayout {
                 Layout.fillWidth: true
                 Slider { id: diskTempWarnSlider; from: 30; to: 80; stepSize: 5; value: 45; Layout.fillWidth: true }
-                Label { text: Math.round(diskTempWarnSlider.value) + "°C"; Layout.preferredWidth: 40 }
+                Label { text: colorsPage.formatThresholdTemp(diskTempWarnSlider.value); Layout.preferredWidth: 40 }
             }
             RowLayout {
                 Layout.fillWidth: true
                 Slider { id: diskTempCritSlider; from: 30; to: 80; stepSize: 5; value: 60; Layout.fillWidth: true }
-                Label { text: Math.round(diskTempCritSlider.value) + "°C"; Layout.preferredWidth: 40 }
+                Label { text: colorsPage.formatThresholdTemp(diskTempCritSlider.value); Layout.preferredWidth: 40 }
             }
             Rectangle { Layout.preferredWidth: 10; Layout.preferredHeight: 10; radius: 5; color: diskTempWarnSlider.value >= diskTempCritSlider.value ? cfg_criticalColor : "transparent" }
         }

--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -14,6 +14,8 @@ KCM.SimpleKCM {
     property string cfg_displayMode: "text"
     property string cfg_fontFamily: "monospace"
     property string cfg_layoutType: "horizontal"
+    property string cfg_tempUnit: "C"
+    property string cfg_networkUnit: "bytes"
 
     readonly property var displayModes: ["text", "icons", "icons+text"]
     readonly property var displayModeLabels: [i18n("Text"), i18n("Icons"), i18n("Icons + Text")]
@@ -117,6 +119,27 @@ KCM.SimpleKCM {
         Label {
             text: (intervalSlider.value / 1000).toFixed(1) + " " + i18n("seconds")
             opacity: 0.7
+        }
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: i18n("Unit Preferences")
+        }
+
+        ComboBox {
+            id: tempUnitCombo
+            Kirigami.FormData.label: i18n("Temperature unit:")
+            model: [i18n("Celsius (°C)"), i18n("Fahrenheit (°F)")]
+            currentIndex: cfg_tempUnit === "F" ? 1 : 0
+            onActivated: cfg_tempUnit = (currentIndex === 1 ? "F" : "C")
+        }
+
+        ComboBox {
+            id: networkUnitCombo
+            Kirigami.FormData.label: i18n("Network/Disk I/O unit:")
+            model: [i18n("Bytes/s  (KB, MB)"), i18n("Bits/s  (Kbps, Mbps)")]
+            currentIndex: cfg_networkUnit === "bits" ? 1 : 0
+            onActivated: cfg_networkUnit = (currentIndex === 1 ? "bits" : "bytes")
         }
     }
 }

--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -137,7 +137,7 @@ KCM.SimpleKCM {
         ComboBox {
             id: networkUnitCombo
             Kirigami.FormData.label: i18n("Network/Disk I/O unit:")
-            model: [i18n("Bytes/s  (KB, MB)"), i18n("Bits/s  (Kbps, Mbps)")]
+            model: [i18n("Bytes  (KB, MB)"), i18n("Bits  (Kb, Mb)")]
             currentIndex: cfg_networkUnit === "bits" ? 1 : 0
             onActivated: cfg_networkUnit = (currentIndex === 1 ? "bits" : "bytes")
         }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -62,6 +62,8 @@ PlasmoidItem {
     })
 
     property int updateInterval: Plasmoid.configuration.updateInterval || 2000
+    property string tempUnit: Plasmoid.configuration.tempUnit || "C"
+    property string networkUnit: Plasmoid.configuration.networkUnit || "bytes"
 
     // --- Color configuration properties ---
 
@@ -142,6 +144,7 @@ PlasmoidItem {
     TempSensors {
         id: temp
         updateInterval: root.updateInterval
+        tempUnit: root.tempUnit
     }
 
     GpuSensors {
@@ -149,6 +152,7 @@ PlasmoidItem {
         updateInterval: root.updateInterval
         gpuSelection: root.gpuSelection
         gpuLabels: root.gpuLabels
+        tempUnit: root.tempUnit
     }
 
     BatterySensors {
@@ -161,12 +165,15 @@ PlasmoidItem {
         id: network
         updateInterval: root.updateInterval
         networkInterface: root.networkInterface
+        networkUnit: root.networkUnit
     }
 
     DiskSensors {
         id: disk
         updateInterval: root.updateInterval
         enabled: root.showDisk
+        tempUnit: root.tempUnit
+        networkUnit: root.networkUnit
     }
 
     // --- Representations ---

--- a/contents/ui/sensors/DiskSensors.qml
+++ b/contents/ui/sensors/DiskSensors.qml
@@ -7,13 +7,15 @@ Item {
 
     property int updateInterval: 2000
     property bool enabled: true
+    property string tempUnit: "C"
+    property string networkUnit: "bytes"
 
-    readonly property string diskReadValue:  Utils.formatRate(diskReadSensor.status  === Sensors.Sensor.Ready ? diskReadSensor.value  : NaN)
-    readonly property string diskWriteValue: Utils.formatRate(diskWriteSensor.status === Sensors.Sensor.Ready ? diskWriteSensor.value : NaN)
+    readonly property string diskReadValue:  Utils.formatRate(diskReadSensor.status  === Sensors.Sensor.Ready ? diskReadSensor.value  : NaN, networkUnit)
+    readonly property string diskWriteValue: Utils.formatRate(diskWriteSensor.status === Sensors.Sensor.Ready ? diskWriteSensor.value : NaN, networkUnit)
 
-    // Highest temperature found across all discovered drive temp sensors (°C)
+    // Highest temperature found across all discovered drive temp sensors
     readonly property real   diskTempNumber: _diskTempNum
-    readonly property string diskTempValue:  isNaN(_diskTempNum) ? "" : Math.round(_diskTempNum) + "°C"
+    readonly property string diskTempValue:  isNaN(_diskTempNum) ? "" : Utils.formatTemp(_diskTempNum, tempUnit)
 
     property real _diskTempNum: NaN
 

--- a/contents/ui/sensors/GpuSensors.qml
+++ b/contents/ui/sensors/GpuSensors.qml
@@ -13,6 +13,9 @@ Item {
     // User-defined labels: "gpu0:My iGPU,gpu1:dGPU". Empty string = use default "GPU N" name.
     property string gpuLabels: ""
 
+    // Temperature unit: "C" (default) or "F"
+    property string tempUnit: "C"
+
     // List of { id: "gpu0", name: "GPU 1" } derived from SensorTreeModel (no polling)
     readonly property var discoveredGpus: _discovered
     property var _discovered: []
@@ -174,7 +177,7 @@ Item {
                 vStr = Utils.formatBytes(vuVal) + "/" + Utils.formatBytes(vtVal) + "G";
             // tVal === 0 is ksystemstats' null sentinel for iGPU: no hwmon node exists,
             // so the driver reports exactly 0. No real GPU can be at or below 0°C.
-            var tStr = (isNaN(tVal) || tVal <= 0) ? "" : Math.round(tVal) + "°C";
+            var tStr = (isNaN(tVal) || tVal <= 0) ? "" : Utils.formatTemp(tVal, tempUnit);
 
             newList.push({ id: g, name: name,
                            usage: uStr, vram: vStr, temp: tStr,
@@ -197,10 +200,11 @@ Item {
         _vramStr  = (hasVram && totalVramTotal > 0)
                     ? Utils.formatBytes(totalVramUsed) + "/" + Utils.formatBytes(totalVramTotal) + "G" : "";
         _tempNum  = isNaN(maxTemp) ? NaN : maxTemp;
-        _tempStr  = isNaN(maxTemp) ? "" : Math.round(maxTemp) + "°C";
+        _tempStr  = isNaN(maxTemp) ? "" : Utils.formatTemp(maxTemp, tempUnit);
     }
 
-    // Re-aggregate when labels or selection change so panel updates immediately
+    // Re-aggregate when labels, selection, or unit change so panel updates immediately
     onGpuLabelsChanged:    aggregate()
     onGpuSelectionChanged: aggregate()
+    onTempUnitChanged:     aggregate()
 }

--- a/contents/ui/sensors/NetworkSensors.qml
+++ b/contents/ui/sensors/NetworkSensors.qml
@@ -6,6 +6,7 @@ Item {
 
     property int updateInterval: 2000
     property string networkInterface: "auto"
+    property string networkUnit: "bytes"
 
     readonly property string netIfacePath: {
         if (networkInterface === "" || networkInterface === "auto")
@@ -15,12 +16,12 @@ Item {
 
     readonly property string netDownValue: {
         if (netDownSensor.status !== Sensors.Sensor.Ready) return "...";
-        return Utils.formatRate(netDownSensor.value);
+        return Utils.formatRate(netDownSensor.value, networkUnit);
     }
 
     readonly property string netUpValue: {
         if (netUpSensor.status !== Sensors.Sensor.Ready) return "...";
-        return Utils.formatRate(netUpSensor.value);
+        return Utils.formatRate(netUpSensor.value, networkUnit);
     }
 
     Sensors.Sensor {

--- a/contents/ui/sensors/TempSensors.qml
+++ b/contents/ui/sensors/TempSensors.qml
@@ -5,6 +5,7 @@ Item {
     id: root
 
     property int updateInterval: 2000
+    property string tempUnit: "C"
 
     readonly property real tempNumericValue: {
         if (tempSensor.status !== Sensors.Sensor.Ready)
@@ -14,7 +15,7 @@ Item {
 
     readonly property string tempValue: {
         if (isNaN(tempNumericValue)) return "--";
-        return Math.round(tempNumericValue) + "°C";
+        return Utils.formatTemp(tempNumericValue, tempUnit);
     }
 
     Sensors.Sensor {

--- a/contents/ui/sensors/Utils.qml
+++ b/contents/ui/sensors/Utils.qml
@@ -10,14 +10,30 @@ QtObject {
         return gb.toFixed(1);
     }
 
-    function formatRate(bytesPerSec) {
+    // unit: "bytes" (default, KB/MB) or "bits" (Kb/Mb)
+    // Suffix convention: uppercase B = bytes, lowercase b = bits
+    function formatRate(bytesPerSec, unit) {
         if (typeof bytesPerSec !== "number" || isNaN(bytesPerSec))
             return "...";
-        var kbps = bytesPerSec / 1024;
-        if (kbps >= 1024) {
-            return (kbps / 1024).toFixed(1) + "M";
+        if (unit === "bits") {
+            var bps = bytesPerSec * 8;
+            if (bps >= 1000000)
+                return (bps / 1000000).toFixed(1) + "Mb";
+            return Math.max(0, bps / 1000).toFixed(1) + "Kb";
         }
-        return Math.max(0, kbps).toFixed(1) + "K";
+        var kbps = bytesPerSec / 1024;
+        if (kbps >= 1024)
+            return (kbps / 1024).toFixed(1) + "MB";
+        return Math.max(0, kbps).toFixed(1) + "KB";
+    }
+
+    // celsiusValue: raw °C number from sensor; unit: "C" or "F"
+    function formatTemp(celsiusValue, unit) {
+        if (typeof celsiusValue !== "number" || isNaN(celsiusValue))
+            return "";
+        if (unit === "F")
+            return Math.round(celsiusValue * 9 / 5 + 32) + "°F";
+        return Math.round(celsiusValue) + "°C";
     }
 
     function sensorValueOrNaN(sensor) {


### PR DESCRIPTION
## Description

- Added new `tempUnit` (Celsius/Fahrenheit) and `networkUnit` (Bytes/Bits) settings
- Created "Unit Preferences" configuration section in General settings tab
- Refactored `Utils.qml` formatters to respect chosen units, adding B/b suffixes for data rates to disambiguate (e.g., MB/s vs Mb/s)
- Piped unit preferences down to CPU, GPU, Disk, and Network sensor components
- Dynamically updated threshold slider labels in Colors configuration to reflect the chosen temperature unit (while preserving backend logic in °C)

## Testing

- [x] Tested on KDE Plasma 6.6.4
- [x] Distro: Fedora Linux 43
- [x] Widget installs cleanly with `install.sh.`
- [x] Widget displays correctly in the panel


## Screenshots

<img width="500" height="52" alt="image" src="https://github.com/user-attachments/assets/de713512-df6c-4988-99cb-df1a7ff344ea" />