### PR TITLE
chore: prepare release 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to KVitals will be documented in this file.
 
+## [2.8.0] - 2026-05-22
+
+### Added
+
+- **Disk I/O & Temperature** (`Metrics` settings — Disk I/O & Temp): New metric showing real-time disk read/write rates and the highest drive temperature across all NVMe and SATA drives. Displayed as `DSK: ↓2.1MB ↑76KB · 42°C` in the compact panel (#36).
+  - Drive temperatures are discovered dynamically via `SensorTreeModel` + `lmsensors` (supports `nvme-pci-*` and `drivetemp-scsi-*` chips) — zero polling overhead when the metric is disabled.
+  - Dedicated **Disk Temp** threshold sliders added to the Colors settings page (default: warning 45°C, critical 60°C).
+- **Unit Preferences** (`General` settings — Unit Preferences section): Choose display units globally across all metrics (#37).
+  - **Temperature**: Celsius (°C, default) or Fahrenheit (°F). Applies to CPU temp, GPU temp, and Disk temp everywhere — panel, popup, and tooltip.
+  - **Network / Disk I/O**: Bytes (KB/MB, default) or Bits (Kb/Mb). Applies to Network and Disk I/O rates. Suffix convention follows industry standard: uppercase `B` = bytes, lowercase `b` = bits.
+  - Threshold slider labels in the Colors settings page update live to reflect the chosen temperature unit (stored values remain in °C for correct sensor comparison).
+
 ## [2.7.0] - 2026-05-15
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,11 +9,27 @@ Have a suggestion? Open an issue or start a discussion on GitHub.
 ## Currently Supported Metrics
 
 - CPU Usage
-- RAM Usage
 - CPU Temperature
-- GPU (Usage, VRAM, Temperature)
+- CPU Frequency
+- RAM Usage
+- GPU (Usage, VRAM, Temperature) — with multi-GPU and custom labels
 - Battery & Power Consumption
 - Network Speed (Download/Upload)
+- Disk I/O (Read/Write rates)
+- Disk Temperature (highest across all NVMe/SATA drives)
+
+---
+
+## Currently Supported UX Features
+
+- Custom metric order (drag to reorder)
+- Per-metric compact panel visibility toggle
+- Metric grouping (merge CPU+Temp, Battery+Power, split GPU)
+- Threshold-based coloring (warning/critical per metric)
+- Custom font color
+- Display modes: Text, Icons, Icons+Text
+- Horizontal / Vertical layout
+- **Unit Preferences** (°C/°F, Bytes/Bits)
 
 ---
 
@@ -25,11 +41,9 @@ Have a suggestion? Open an issue or start a discussion on GitHub.
 
 These sensors are exposed by `ksystemstats` and are planned for future releases:
 
-- **CPU Frequency** — Average, min, and max frequency via `cpu/all/averageFrequency`
+- **Disk Usage** — Used/free space per partition via `disk/all/usedPercent` or per-disk breakdown
 - **CPU Load Averages** — 1, 5, and 15-minute averages via `cpu/loadaverages/*`
 - **Swap Usage** — Used/total swap memory via `memory/swap/*`
-- **Disk I/O** — Read/write rates via `disk/all/read` and `disk/all/write`
-- **Disk Usage** — Used/free space percentage via `disk/all/usedPercent`
 - **GPU Frequency & Power** — Core frequency and power draw via `gpu/<device>/coreFrequency` and `gpu/<device>/power`
 - **Battery Health** — Degradation percentage via `power/<device>/health`
 - **System Uptime** — Via `os/system/uptime`
@@ -39,7 +53,6 @@ These sensors are exposed by `ksystemstats` and are planned for future releases:
 These require `lmsensors` to be installed and configured:
 
 - **Fan Speed** — CPU fan RPM (where available)
-- **NVMe Temperature** — Drive temperature (where available)
 
 ### UX & Configuration
 

--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
       }
     ],
     "Website": "https://github.com/yassine20011/kvitals",
-    "Version": "2.7.0",
+    "Version": "2.8.0",
     "License": "GPL-3.0"
   },
   "KPackageStructure": "Plasma/Applet",


### PR DESCRIPTION
## Description

- Bump version to 2.8.0 in metadata.json
- Add v2.8.0 changelog entry (Disk I/O & Temperature, Unit Preferences)
- Update ROADMAP: mark Disk I/O and Unit Preferences as shipped, add UX features section, promote Disk Usage as next target, remove NVMe Temperature (now covered by Disk Temperature)

