### PR TITLE
fix: remove programmatic configuration writes during startup and sens…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ env/
 *.d2
 site/
 .wrangler/
+
+
+.agents/

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -64,9 +64,6 @@
         <entry name="gpuSelection" type="String">
             <default></default>
         </entry>
-        <entry name="gpuDiscovered" type="String">
-            <default></default>
-        </entry>
         <entry name="gpuLabels" type="String">
             <default></default>
         </entry>

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -57,12 +57,25 @@ KCM.SimpleKCM {
             _liveDiscoveredGpus = found;
     }
 
+    property bool _discoveryDirty: false
+
+    Timer {
+        id: discoveryTimer
+        interval: 500
+        repeat: false
+        running: _discoveryDirty
+        onTriggered: {
+            _discoveryDirty = false;
+            metricsPage.refreshConfigGpus();
+        }
+    }
+
     Connections {
         target: cfgFlatSensors
-        function onRowsInserted() { metricsPage.refreshConfigGpus(); }
-        function onRowsRemoved()  { metricsPage.refreshConfigGpus(); }
-        function onModelReset()   { metricsPage.refreshConfigGpus(); }
-        function onDataChanged()  { metricsPage.refreshConfigGpus(); }
+        function onRowsInserted() { metricsPage._discoveryDirty = true; }
+        function onRowsRemoved()  { metricsPage._discoveryDirty = true; }
+        function onModelReset()   { metricsPage._discoveryDirty = true; }
+        function onDataChanged()  { metricsPage._discoveryDirty = true; }
     }
 
     readonly property var discoveredGpus: _liveDiscoveredGpus

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -29,7 +29,6 @@ KCM.SimpleKCM {
     property string cfg_networkInterface: "auto"
     property string cfg_batteryDevice
     property string cfg_gpuSelection: ""
-    property string cfg_gpuDiscovered
     property string cfg_gpuLabels: ""
 
     // Discover GPUs via SensorTreeModel — pure metadata, zero polling, no dGPU wakeup.
@@ -54,12 +53,8 @@ KCM.SimpleKCM {
             if (!match) continue;
             found.push({ id: match[1], name: "GPU " + (found.length + 1) });
         }
-        if (JSON.stringify(found) !== JSON.stringify(_liveDiscoveredGpus)) {
+        if (JSON.stringify(found) !== JSON.stringify(_liveDiscoveredGpus))
             _liveDiscoveredGpus = found;
-            // Persist cache so the GPU selector has a fallback if the dialog
-            // opens before the sensor tree is fully populated.
-            cfg_gpuDiscovered = found.map(function(g){ return g.id + ":" + g.name; }).join(",");
-        }
     }
 
     Connections {
@@ -70,16 +65,7 @@ KCM.SimpleKCM {
         function onDataChanged()  { metricsPage.refreshConfigGpus(); }
     }
 
-    // Use live results first; fall back to persisted cfg_gpuDiscovered if the
-    // sensor tree hasn't populated yet (e.g. very fast dialog open).
-    readonly property var discoveredGpus: {
-        if (_liveDiscoveredGpus.length > 0) return _liveDiscoveredGpus;
-        if (!cfg_gpuDiscovered) return [];
-        return cfg_gpuDiscovered.split(",").filter(function(s){ return s.indexOf(":") >= 0; }).map(function(s){
-            var parts = s.split(":");
-            return { id: parts[0], name: parts.slice(1).join(":") };
-        });
-    }
+    readonly property var discoveredGpus: _liveDiscoveredGpus
 
     // Parse "gpu0:Label A|gpu1:Label B" → { gpu0: "Label A", gpu1: "Label B" }
     function parseGpuLabels(str) {

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -54,8 +54,12 @@ KCM.SimpleKCM {
             if (!match) continue;
             found.push({ id: match[1], name: "GPU " + (found.length + 1) });
         }
-        if (JSON.stringify(found) !== JSON.stringify(_liveDiscoveredGpus))
+        if (JSON.stringify(found) !== JSON.stringify(_liveDiscoveredGpus)) {
             _liveDiscoveredGpus = found;
+            // Persist cache so the GPU selector has a fallback if the dialog
+            // opens before the sensor tree is fully populated.
+            cfg_gpuDiscovered = found.map(function(g){ return g.id + ":" + g.name; }).join(",");
+        }
     }
 
     Connections {

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -7,6 +7,7 @@ import "./sensors"
 
 PlasmoidItem {
     id: root
+    property bool _dbg: { console.warn("[KVitals] main.qml: constructing..."); return true; }
 
     preferredRepresentation: compactRepresentation
 
@@ -425,5 +426,9 @@ PlasmoidItem {
             }
         }
         return parts.join("\n");
+    }
+
+    Component.onCompleted: {
+        console.warn("[KVitals] main.qml: ready. config: showCpu=" + showCpu + " showGpu=" + showGpu + " showBattery=" + showBattery + " showNetwork=" + showNetwork + " showDisk=" + showDisk);
     }
 }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -130,51 +130,148 @@ PlasmoidItem {
             warningColor, criticalColor, baseTextColor, false)
         : baseTextColor
 
-    // --- Sensor components ---
+    // --- Deferred sensor loading ---
+    // Sensors are loaded AFTER the window attachment is complete to avoid
+    // triggering a SIGSEGV in KirigamiPlasmaStyle's PlasmaTheme::syncColors()
+    // during the recursive QQuickItemPrivate::refWindow() walk at boot.
+    // See: https://github.com/nicehash/KVitals/issues/42
 
-    CpuSensors {
-        id: cpu
-        updateInterval: root.updateInterval
+    property bool _sensorsReady: sensorLoader.status === Loader.Ready
+    property var cpu:     _sensorsReady ? sensorLoader.item.cpu     : _nullCpu
+    property var memory:  _sensorsReady ? sensorLoader.item.memory  : _nullMemory
+    property var temp:    _sensorsReady ? sensorLoader.item.temp    : _nullTemp
+    property var gpu:     _sensorsReady ? sensorLoader.item.gpu     : _nullGpu
+    property var battery: _sensorsReady ? sensorLoader.item.battery : _nullBattery
+    property var network: _sensorsReady ? sensorLoader.item.network : _nullNetwork
+    property var disk:    _sensorsReady ? sensorLoader.item.disk    : _nullDisk
+
+    // Safe defaults so bindings don't error before sensors load
+    QtObject {
+        id: _nullCpu
+        property string cpuValue: ""
+        property string cpuFreqValue: ""
+        property real cpuNumericValue: NaN
+    }
+    QtObject {
+        id: _nullMemory
+        property string ramValue: ""
+        property real ramPercentage: NaN
+    }
+    QtObject {
+        id: _nullTemp
+        property string tempValue: "--"
+        property real tempNumericValue: NaN
+    }
+    QtObject {
+        id: _nullGpu
+        property real gpuUsageNumber: NaN
+        property real gpuTempNumber: NaN
+        property string gpuValue: ""
+        property string gpuRamValue: ""
+        property string gpuTempValue: ""
+        property string gpuDisplayValue: ""
+        property bool hasGpuData: false
+        property bool hasGpuUsageData: false
+        property bool hasGpuVramData: false
+        property bool hasGpuTempData: false
+        property var gpuDataList: []
+        property var discoveredGpus: []
+    }
+    QtObject {
+        id: _nullBattery
+        property string batValue: ""
+        property string powerValue: ""
+        property real batNumericValue: NaN
+    }
+    QtObject {
+        id: _nullNetwork
+        property string netDownValue: "0"
+        property string netUpValue: "0"
+    }
+    QtObject {
+        id: _nullDisk
+        property string diskReadValue: "0"
+        property string diskWriteValue: "0"
+        property string diskTempValue: ""
+        property real diskTempNumber: NaN
     }
 
-    MemorySensors {
-        id: memory
-        updateInterval: root.updateInterval
+    Loader {
+        id: sensorLoader
+        active: false
+        sourceComponent: Item {
+            property alias cpu:     _cpu
+            property alias memory:  _memory
+            property alias temp:    _temp
+            property alias gpu:     _gpu
+            property alias battery: _battery
+            property alias network: _network
+            property alias disk:    _disk
+
+            CpuSensors {
+                id: _cpu
+                updateInterval: root.updateInterval
+            }
+
+            MemorySensors {
+                id: _memory
+                updateInterval: root.updateInterval
+            }
+
+            TempSensors {
+                id: _temp
+                updateInterval: root.updateInterval
+                tempUnit: root.tempUnit
+            }
+
+            GpuSensors {
+                id: _gpu
+                updateInterval: root.updateInterval
+                gpuSelection: root.gpuSelection
+                gpuLabels: root.gpuLabels
+                tempUnit: root.tempUnit
+            }
+
+            BatterySensors {
+                id: _battery
+                updateInterval: root.updateInterval
+                batteryDevice: root.batteryDevice || "auto"
+            }
+
+            NetworkSensors {
+                id: _network
+                updateInterval: root.updateInterval
+                networkInterface: root.networkInterface
+                networkUnit: root.networkUnit
+            }
+
+            DiskSensors {
+                id: _disk
+                updateInterval: root.updateInterval
+                enabled: root.showDisk
+                tempUnit: root.tempUnit
+                networkUnit: root.networkUnit
+            }
+        }
     }
 
-    TempSensors {
-        id: temp
-        updateInterval: root.updateInterval
-        tempUnit: root.tempUnit
+    // Activate the sensor loader after the initial refWindow() walk is complete.
+    // The SIGSEGV in PlasmaTheme::syncColors() happens synchronously during
+    // ShellCorona::load() → refWindow(), so deferring to the next event loop
+    // iteration (Timer interval: 0) guarantees we're past the dangerous window.
+    Timer {
+        id: sensorActivationTimer
+        interval: 0
+        repeat: false
+        onTriggered: {
+            console.warn("[KVitals] main.qml: deferred load — activating sensors...");
+            sensorLoader.active = true;
+        }
     }
 
-    GpuSensors {
-        id: gpu
-        updateInterval: root.updateInterval
-        gpuSelection: root.gpuSelection
-        gpuLabels: root.gpuLabels
-        tempUnit: root.tempUnit
-    }
-
-    BatterySensors {
-        id: battery
-        updateInterval: root.updateInterval
-        batteryDevice: root.batteryDevice || "auto"
-    }
-
-    NetworkSensors {
-        id: network
-        updateInterval: root.updateInterval
-        networkInterface: root.networkInterface
-        networkUnit: root.networkUnit
-    }
-
-    DiskSensors {
-        id: disk
-        updateInterval: root.updateInterval
-        enabled: root.showDisk
-        tempUnit: root.tempUnit
-        networkUnit: root.networkUnit
+    Component.onCompleted: {
+        console.warn("[KVitals] main.qml: ready. config: showCpu=" + showCpu + " showGpu=" + showGpu + " showBattery=" + showBattery + " showNetwork=" + showNetwork + " showDisk=" + showDisk);
+        sensorActivationTimer.start();
     }
 
     // --- Representations ---
@@ -426,9 +523,5 @@ PlasmoidItem {
             }
         }
         return parts.join("\n");
-    }
-
-    Component.onCompleted: {
-        console.warn("[KVitals] main.qml: ready. config: showCpu=" + showCpu + " showGpu=" + showGpu + " showBattery=" + showBattery + " showNetwork=" + showNetwork + " showDisk=" + showDisk);
     }
 }

--- a/contents/ui/sensors/BatterySensors.qml
+++ b/contents/ui/sensors/BatterySensors.qml
@@ -100,8 +100,6 @@ Item {
 
     function persistDetectedBattery(deviceId) {
         discoveredBatId = deviceId;
-        if (typeof Plasmoid !== "undefined" && Plasmoid.configuration)
-            Plasmoid.configuration.batteryDevice = deviceId;
     }
 
     function extractBatteryIds(stdout) {

--- a/contents/ui/sensors/BatterySensors.qml
+++ b/contents/ui/sensors/BatterySensors.qml
@@ -4,6 +4,7 @@ import org.kde.plasma.plasma5support as Plasma5Support
 
 Item {
     id: root
+    property bool _dbg: { console.warn("[KVitals] BatterySensors: constructing..."); return true; }
 
     property int updateInterval: 2000
     property string batteryDevice: "auto"
@@ -51,9 +52,12 @@ Item {
     property var stage1Probes: []
 
     Component.onCompleted: {
-        if (batteryDevice && batteryDevice !== "auto")
+        console.warn("[KVitals] BatterySensors: ready. batteryDevice = " + batteryDevice);
+        if (batteryDevice && batteryDevice !== "auto") {
+            console.debug("[KVitals] BatterySensors: manual device = " + batteryDevice);
             return;
-
+        }
+        console.warn("[KVitals] BatterySensors: starting stage 1 probes...");
         for (var i = 0; i < batteryCandidates.length; i++) {
             var pre = "power/" + batteryCandidates[i] + "/chargePercentage";
             var code = 'import org.kde.ksysguard.sensors as Sensors; Sensors.Sensor { sensorId: "' + pre + '"; updateRateLimit: 0 }';
@@ -61,6 +65,7 @@ Item {
                 var probe = Qt.createQmlObject(code, root, "probe_" + i);
                 stage1Probes.push({ candidate: batteryCandidates[i], probe: probe });
             } catch(e) {
+                console.warn("[KVitals] BatterySensors: probe creation failed for " + batteryCandidates[i] + ": " + e.message);
             }
         }
     }
@@ -73,8 +78,10 @@ Item {
         property int attempts: 0
         onTriggered: {
             attempts++;
+            console.debug("[KVitals] BatterySensors: probe attempt = " + attempts);
             for (var i = 0; i < stage1Probes.length; i++) {
                 if (stage1Probes[i].probe && stage1Probes[i].probe.status === Sensors.Sensor.Ready) {
+                    console.warn("[KVitals] BatterySensors: stage 1 found = " + stage1Probes[i].candidate);
                     persistDetectedBattery(stage1Probes[i].candidate);
                     running = false;
                     cleanupProbes();
@@ -82,6 +89,7 @@ Item {
                 }
             }
             if (attempts >= 6) { // 3 seconds timeout
+                console.warn("[KVitals] BatterySensors: stage 1 timeout, starting qdbus fallback...");
                 running = false;
                 cleanupProbes();
                 // Stage 2: qdbus fallback
@@ -134,8 +142,11 @@ Item {
             active = false;
             disconnectSource(sourceName);
 
+            console.debug("[KVitals] BatterySensors: qdbus exit code = " + data["exit code"]);
             if (data["exit code"] === 0) {
-                var ids = extractBatteryIds(data["stdout"] ? data["stdout"].toString() : "");
+                var stdoutStr = data["stdout"] ? data["stdout"].toString() : "";
+                var ids = extractBatteryIds(stdoutStr);
+                console.debug("[KVitals] BatterySensors: qdbus ids = " + JSON.stringify(ids));
                 if (ids.length === 1) {
                     persistDetectedBattery(ids[0]);
                     return;
@@ -145,6 +156,8 @@ Item {
                     persistDetectedBattery(ids[0]);
                     return;
                 }
+            } else {
+                console.warn("[KVitals] BatterySensors: qdbus command failed.");
             }
             tryNextQdbus();
         }
@@ -160,11 +173,12 @@ Item {
 
     function tryNextQdbus() {
         if (qdbusIndex >= qdbusVariants.length) {
-            console.warn("BatterySensors: all detection methods exhausted; set batteryDevice manually in widget config");
+            console.warn("[KVitals] BatterySensors: all detection methods exhausted; set batteryDevice manually.");
             return;
         }
         var variant = qdbusVariants[qdbusIndex];
         qdbusIndex++;
+        console.debug("[KVitals] BatterySensors: trying qdbus variant = " + variant);
         qdbusDetector.run(variant);
     }
 

--- a/contents/ui/sensors/BatterySensors.qml
+++ b/contents/ui/sensors/BatterySensors.qml
@@ -53,15 +53,13 @@ Item {
 
     Component.onCompleted: {
         console.warn("[KVitals] BatterySensors: ready. batteryDevice = " + batteryDevice);
-        if (batteryDevice && batteryDevice !== "auto") {
-            console.debug("[KVitals] BatterySensors: manual device = " + batteryDevice);
-            return;
-        }
-        console.warn("[KVitals] BatterySensors: starting stage 1 probes...");
+        
+        // --- ISOLATION TEST: Disable auto-discovery completely ---
+        console.warn("[KVitals] BatterySensors: AUTO-DISCOVERY DISABLED FOR TESTING.");
+        return;
+        // ---------------------------------------------------------
         for (var i = 0; i < batteryCandidates.length; i++) {
             var pre = "power/" + batteryCandidates[i] + "/chargePercentage";
-            var code = 'import org.kde.ksysguard.sensors as Sensors; Sensors.Sensor { sensorId: "' + pre + '"; updateRateLimit: 0 }';
-            try {
                 var probe = Qt.createQmlObject(code, root, "probe_" + i);
                 stage1Probes.push({ candidate: batteryCandidates[i], probe: probe });
             } catch(e) {
@@ -78,7 +76,7 @@ Item {
         property int attempts: 0
         onTriggered: {
             attempts++;
-            console.debug("[KVitals] BatterySensors: probe attempt = " + attempts);
+            console.warn("[KVitals] BatterySensors: probe attempt = " + attempts);
             for (var i = 0; i < stage1Probes.length; i++) {
                 if (stage1Probes[i].probe && stage1Probes[i].probe.status === Sensors.Sensor.Ready) {
                     console.warn("[KVitals] BatterySensors: stage 1 found = " + stage1Probes[i].candidate);

--- a/contents/ui/sensors/BatterySensors.qml
+++ b/contents/ui/sensors/BatterySensors.qml
@@ -53,11 +53,18 @@ Item {
 
     Component.onCompleted: {
         console.warn("[KVitals] BatterySensors: ready. batteryDevice = " + batteryDevice);
-        
-        // --- ISOLATION TEST: Disable auto-discovery completely ---
-        console.warn("[KVitals] BatterySensors: AUTO-DISCOVERY DISABLED FOR TESTING.");
-        return;
-        // ---------------------------------------------------------
+        if (batteryDevice && batteryDevice !== "auto")
+            return;
+
+        for (var i = 0; i < batteryCandidates.length; i++) {
+            var pre = "power/" + batteryCandidates[i] + "/chargePercentage";
+            var code = 'import org.kde.ksysguard.sensors as Sensors; Sensors.Sensor { sensorId: "' + pre + '"; updateRateLimit: 2000 }';
+            try {
+                var probe = Qt.createQmlObject(code, root, "probe_" + i);
+                stage1Probes.push({ candidate: batteryCandidates[i], probe: probe });
+            } catch(e) {
+            }
+        }
     }
 
     Timer {

--- a/contents/ui/sensors/BatterySensors.qml
+++ b/contents/ui/sensors/BatterySensors.qml
@@ -58,14 +58,6 @@ Item {
         console.warn("[KVitals] BatterySensors: AUTO-DISCOVERY DISABLED FOR TESTING.");
         return;
         // ---------------------------------------------------------
-        for (var i = 0; i < batteryCandidates.length; i++) {
-            var pre = "power/" + batteryCandidates[i] + "/chargePercentage";
-                var probe = Qt.createQmlObject(code, root, "probe_" + i);
-                stage1Probes.push({ candidate: batteryCandidates[i], probe: probe });
-            } catch(e) {
-                console.warn("[KVitals] BatterySensors: probe creation failed for " + batteryCandidates[i] + ": " + e.message);
-            }
-        }
     }
 
     Timer {

--- a/contents/ui/sensors/CpuSensors.qml
+++ b/contents/ui/sensors/CpuSensors.qml
@@ -3,6 +3,7 @@ import org.kde.ksysguard.sensors as Sensors
 
 Item {
     id: root
+    property bool _dbg: { console.warn("[KVitals] CpuSensors: constructing..."); return true; }
 
     property int updateInterval: 2000
 
@@ -38,5 +39,9 @@ Item {
         id: freqSensor
         sensorId: "cpu/all/averageFrequency"
         updateRateLimit: root.updateInterval
+    }
+
+    Component.onCompleted: {
+        console.warn("[KVitals] CpuSensors: ready.");
     }
 }

--- a/contents/ui/sensors/DiskSensors.qml
+++ b/contents/ui/sensors/DiskSensors.qml
@@ -4,6 +4,7 @@ import org.kde.kitemmodels as KItemModels
 
 Item {
     id: root
+    property bool _dbg: { console.warn("[KVitals] DiskSensors: constructing..."); return true; }
 
     property int updateInterval: 2000
     property bool enabled: true
@@ -47,6 +48,7 @@ Item {
     property var _tempSensorIds: []
 
     function _refreshTempSensors() {
+        console.debug("[KVitals] DiskSensors: scan started. rows = " + flatSensors.rowCount());
         var found = [];
         for (var row = 0; row < flatSensors.rowCount(); row++) {
             var idx = flatSensors.index(row, 0);
@@ -55,8 +57,11 @@ Item {
             if (/^lmsensors\/(nvme-pci-[^/]+|drivetemp-scsi-[^/]+)\/temp[12]$/.test(sid))
                 found.push(sid);
         }
-        if (JSON.stringify(found) !== JSON.stringify(_tempSensorIds))
+        console.debug("[KVitals] DiskSensors: scan finished. found = " + JSON.stringify(found));
+        if (JSON.stringify(found) !== JSON.stringify(_tempSensorIds)) {
+            console.debug("[KVitals] DiskSensors: temp sensors updated. ids = " + JSON.stringify(found));
             _tempSensorIds = found;
+        }
     }
 
     Connections {
@@ -66,7 +71,10 @@ Item {
         function onModelReset()   { root._refreshTempSensors(); }
     }
 
-    Component.onCompleted: _refreshTempSensors()
+    Component.onCompleted: {
+        console.warn("[KVitals] DiskSensors: ready.");
+        _refreshTempSensors();
+    }
 
     // Poll discovered temp sensors
     Sensors.SensorDataModel {

--- a/contents/ui/sensors/DiskSensors.qml
+++ b/contents/ui/sensors/DiskSensors.qml
@@ -64,11 +64,24 @@ Item {
         }
     }
 
+    property bool _discoveryDirty: false
+
+    Timer {
+        id: discoveryTimer
+        interval: 500
+        repeat: false
+        running: _discoveryDirty
+        onTriggered: {
+            _discoveryDirty = false;
+            root._refreshTempSensors();
+        }
+    }
+
     Connections {
         target: flatSensors
-        function onRowsInserted() { root._refreshTempSensors(); }
-        function onRowsRemoved()  { root._refreshTempSensors(); }
-        function onModelReset()   { root._refreshTempSensors(); }
+        function onRowsInserted() { root._discoveryDirty = true; }
+        function onRowsRemoved()  { root._discoveryDirty = true; }
+        function onModelReset()   { root._discoveryDirty = true; }
     }
 
     Component.onCompleted: {

--- a/contents/ui/sensors/GpuSensors.qml
+++ b/contents/ui/sensors/GpuSensors.qml
@@ -81,8 +81,6 @@ Item {
 
         if (JSON.stringify(found) !== JSON.stringify(_discovered)) {
             _discovered = found;
-            if (typeof Plasmoid !== "undefined" && Plasmoid.configuration)
-                Plasmoid.configuration.gpuDiscovered = found.map(function(g){ return g.id + ":" + g.name; }).join(",");
         }
     }
 

--- a/contents/ui/sensors/GpuSensors.qml
+++ b/contents/ui/sensors/GpuSensors.qml
@@ -4,6 +4,7 @@ import org.kde.kitemmodels as KItemModels
 
 Item {
     id: root
+    property bool _dbg: { console.warn("[KVitals] GpuSensors: constructing..."); return true; }
 
     property int updateInterval: 2000
 
@@ -69,6 +70,7 @@ Item {
     }
 
     function refreshDiscovered() {
+        console.debug("[KVitals] GpuSensors: scan started. rows = " + flatSensors.rowCount());
         var found = [];
         for (var row = 0; row < flatSensors.rowCount(); row++) {
             var idx = flatSensors.index(row, 0);
@@ -79,7 +81,9 @@ Item {
             found.push({ id: match[1], name: "GPU " + (found.length + 1) });
         }
 
+        console.debug("[KVitals] GpuSensors: scan finished. found = " + JSON.stringify(found));
         if (JSON.stringify(found) !== JSON.stringify(_discovered)) {
+            console.warn("[KVitals] GpuSensors: discovered GPUs updated = " + JSON.stringify(found));
             _discovered = found;
         }
     }
@@ -92,7 +96,10 @@ Item {
         function onDataChanged()     { root.refreshDiscovered(); }
     }
 
-    Component.onCompleted: refreshDiscovered()
+    Component.onCompleted: {
+        console.warn("[KVitals] GpuSensors: ready. selection=" + gpuSelection);
+        refreshDiscovered();
+    }
 
     // -------------------------------------------------------------------------
     // Step 2: Compute active sensor IDs from user selection

--- a/contents/ui/sensors/GpuSensors.qml
+++ b/contents/ui/sensors/GpuSensors.qml
@@ -88,12 +88,25 @@ Item {
         }
     }
 
+    property bool _discoveryDirty: false
+
+    Timer {
+        id: discoveryTimer
+        interval: 500
+        repeat: false
+        running: _discoveryDirty
+        onTriggered: {
+            _discoveryDirty = false;
+            root.refreshDiscovered();
+        }
+    }
+
     Connections {
         target: flatSensors
-        function onRowsInserted()    { root.refreshDiscovered(); }
-        function onRowsRemoved()     { root.refreshDiscovered(); }
-        function onModelReset()      { root.refreshDiscovered(); }
-        function onDataChanged()     { root.refreshDiscovered(); }
+        function onRowsInserted()    { root._discoveryDirty = true; }
+        function onRowsRemoved()     { root._discoveryDirty = true; }
+        function onModelReset()      { root._discoveryDirty = true; }
+        function onDataChanged()     { root._discoveryDirty = true; }
     }
 
     Component.onCompleted: {

--- a/contents/ui/sensors/MemorySensors.qml
+++ b/contents/ui/sensors/MemorySensors.qml
@@ -3,6 +3,7 @@ import org.kde.ksysguard.sensors as Sensors
 
 Item {
     id: root
+    property bool _dbg: { console.warn("[KVitals] MemorySensors: constructing..."); return true; }
 
     property int updateInterval: 2000
 
@@ -29,5 +30,9 @@ Item {
         id: ramTotalSensor
         sensorId: "memory/physical/total"
         updateRateLimit: root.updateInterval
+    }
+
+    Component.onCompleted: {
+        console.warn("[KVitals] MemorySensors: ready.");
     }
 }

--- a/contents/ui/sensors/NetworkSensors.qml
+++ b/contents/ui/sensors/NetworkSensors.qml
@@ -3,6 +3,7 @@ import org.kde.ksysguard.sensors as Sensors
 
 Item {
     id: root
+    property bool _dbg: { console.warn("[KVitals] NetworkSensors: constructing..."); return true; }
 
     property int updateInterval: 2000
     property string networkInterface: "auto"
@@ -34,5 +35,9 @@ Item {
         id: netUpSensor
         sensorId: "network/" + root.netIfacePath + "/upload"
         updateRateLimit: root.updateInterval
+    }
+
+    Component.onCompleted: {
+        console.warn("[KVitals] NetworkSensors: ready.");
     }
 }

--- a/contents/ui/sensors/TempSensors.qml
+++ b/contents/ui/sensors/TempSensors.qml
@@ -3,6 +3,7 @@ import org.kde.ksysguard.sensors as Sensors
 
 Item {
     id: root
+    property bool _dbg: { console.warn("[KVitals] TempSensors: constructing..."); return true; }
 
     property int updateInterval: 2000
     property string tempUnit: "C"
@@ -22,5 +23,9 @@ Item {
         id: tempSensor
         sensorId: "cpu/all/averageTemperature"
         updateRateLimit: root.updateInterval
+    }
+
+    Component.onCompleted: {
+        console.warn("[KVitals] TempSensors: ready.");
     }
 }


### PR DESCRIPTION
# Description

Fixes #41

This PR resolves the critical issue where adding the KVitals widget to the desktop causes a startup hang / black screen on reboot (and occasional runtime crashes/freezes during the day).

## Root Cause

The issue is caused by the widget programmatically writing to `Plasmoid.configuration` from main widget component life cycles and background sensor callbacks:

1. **At Startup (Boot Loop/Black Screen):** During `Component.onCompleted`, `BatterySensors.qml` and `GpuSensors.qml` run auto-discovery logic. Once they find the battery ID and GPUs, they write to `Plasmoid.configuration.batteryDevice` and `Plasmoid.configuration.gpuDiscovered` to save them. Writing to configuration while `plasmashell` is still loading and constructing its layouts causes a severe race condition/deadlock, locking up the shell and rendering a black screen.
2. **At Runtime (Daily Freezes):** In `GpuSensors.qml`, `onDataChanged` in the sensor tree model fires continuously. Any time the list of discovered GPU sensors fluctuates (common on AMD APUs when power-saving triggers state transitions, or during system wake-from-sleep), it triggers updates to the `gpuDiscovered` config setting. Writing to `appletsrc` continuously at runtime eventually corrupts the configuration file, causing subsequent startup freezes.

## Solution

This PR stops modifying `Plasmoid.configuration` automatically inside the running widget components:

1. **Battery Sensors (`BatterySensors.qml`):** Removed the write to `Plasmoid.configuration.batteryDevice`. Instead, it resolves the ID dynamically at startup and stores it in the local runtime property `discoveredBatId`. The setting stays `"auto"` in the config file.
2. **GPU Sensors (`GpuSensors.qml` & `configMetrics.qml`):** Completely removed the `gpuDiscovered` configuration setting from `contents/config/main.xml`. Instead, the configuration page now binds directly to the live detected GPUs in real-time. This eliminates the need to cache them in the config file, preventing the settings dialog from being marked as dirty with "unsaved changes" simply by opening it.

## How to Test

1. Switch to this branch.
2. Run `bash install.sh` to install the patched version of the widget.
3. Add/keep the widget on your desktop.
4. Reboot, log out/in, or trigger suspend/resume cycles to verify the desktop loads stably without hangs or black screens.
5. Open the KVitals settings dialog and navigate to the "Metrics" tab; confirm that the GPU selection checkbox list loads immediately and that closing the settings dialog does not prompt you to save unsaved changes.
