### PR TITLE
Feat/gpu metric visibility

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -91,6 +91,12 @@
         <entry name="showGpuVram" type="Bool">
             <default>true</default>
         </entry>
+        <entry name="showGpuUsage" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="showGpuTemp" type="Bool">
+            <default>true</default>
+        </entry>
         <entry name="iconSize" type="Int">
             <default>12</default>
         </entry>

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -88,14 +88,8 @@
         <entry name="splitGpu" type="Bool">
             <default>false</default>
         </entry>
-        <entry name="showGpuVram" type="Bool">
-            <default>true</default>
-        </entry>
-        <entry name="showGpuUsage" type="Bool">
-            <default>true</default>
-        </entry>
-        <entry name="showGpuTemp" type="Bool">
-            <default>true</default>
+        <entry name="gpuMetrics" type="String">
+            <default></default>
         </entry>
         <entry name="iconSize" type="Int">
             <default>12</default>

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -88,6 +88,9 @@
         <entry name="splitGpu" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="showGpuVram" type="Bool">
+            <default>true</default>
+        </entry>
         <entry name="iconSize" type="Int">
             <default>12</default>
         </entry>

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -495,6 +495,13 @@ KCM.SimpleKCM {
                     // Reactive per-GPU enabled metrics list
                     property var _activeMetrics: metricsPage.gpuMetricsFor(modelData.id)
 
+                    // True when this GPU is part of the active selection
+                    property bool _gpuEnabled: {
+                        if (!cfg_gpuSelection || cfg_gpuSelection === "") return true;
+                        if (cfg_gpuSelection === "none") return false;
+                        return cfg_gpuSelection.split(",").indexOf(modelData.id) >= 0;
+                    }
+
                     CheckBox {
                         text: modelData.name
                         checked: {
@@ -556,22 +563,22 @@ KCM.SimpleKCM {
                         CheckBox {
                             text: i18n("Usage")
                             checked: gpuDelegate._activeMetrics.indexOf("usage") >= 0
-                            // Disable when it is the only remaining checked item
-                            enabled: cfg_showGpu && !(checked && gpuDelegate._activeMetrics.length <= 1)
+                            // Disable when GPU is inactive or this is the last remaining sub-metric
+                            enabled: cfg_showGpu && gpuDelegate._gpuEnabled && !(checked && gpuDelegate._activeMetrics.length <= 1)
                             onToggled: metricsPage.saveGpuMetric(gpuDelegate.modelData.id, "usage", checked)
                         }
 
                         CheckBox {
                             text: i18n("VRAM")
                             checked: gpuDelegate._activeMetrics.indexOf("vram") >= 0
-                            enabled: cfg_showGpu && !(checked && gpuDelegate._activeMetrics.length <= 1)
+                            enabled: cfg_showGpu && gpuDelegate._gpuEnabled && !(checked && gpuDelegate._activeMetrics.length <= 1)
                             onToggled: metricsPage.saveGpuMetric(gpuDelegate.modelData.id, "vram", checked)
                         }
 
                         CheckBox {
                             text: i18n("Temp")
                             checked: gpuDelegate._activeMetrics.indexOf("temp") >= 0
-                            enabled: cfg_showGpu && !(checked && gpuDelegate._activeMetrics.length <= 1)
+                            enabled: cfg_showGpu && gpuDelegate._gpuEnabled && !(checked && gpuDelegate._activeMetrics.length <= 1)
                             onToggled: metricsPage.saveGpuMetric(gpuDelegate.modelData.id, "temp", checked)
                         }
                     }

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -103,14 +103,59 @@ KCM.SimpleKCM {
             parts.push(id + ":" + labels[id]);
         cfg_gpuLabels = parts.join("|");
     }
+    // Parse "gpu0:usage,vram|gpu1:temp" → { gpu0: ["usage","vram"], gpu1: ["temp"] }
+    function parseGpuMetrics(str) {
+        var result = {};
+        if (!str) return result;
+        var pairs = str.split("|");
+        for (var i = 0; i < pairs.length; i++) {
+            var sep = pairs[i].indexOf(":");
+            if (sep <= 0) continue;
+            var id = pairs[i].substring(0, sep);
+            var metrics = pairs[i].substring(sep + 1).split(",").filter(
+                function(m){ return m === "usage" || m === "vram" || m === "temp"; });
+            if (metrics.length > 0) result[id] = metrics;
+        }
+        return result;
+    }
+
+    // Returns enabled metrics for one GPU (defaults to all three)
+    function gpuMetricsFor(gpuId) {
+        var mm = parseGpuMetrics(cfg_gpuMetrics);
+        return (mm[gpuId] && mm[gpuId].length > 0) ? mm[gpuId] : ["usage", "vram", "temp"];
+    }
+
+    // Toggle one sub-metric for a GPU, save back to cfg_gpuMetrics.
+    // Enforces at-least-one: if only one remains, the call is ignored.
+    function saveGpuMetric(gpuId, metric, enable) {
+        var mm = parseGpuMetrics(cfg_gpuMetrics);
+        var current = mm[gpuId] ? mm[gpuId].slice() : ["usage", "vram", "temp"];
+        if (enable) {
+            if (current.indexOf(metric) < 0) current.push(metric);
+        } else {
+            if (current.length <= 1) return; // enforce minimum one
+            current = current.filter(function(m){ return m !== metric; });
+        }
+        // Sort canonical order
+        var order = ["usage", "vram", "temp"];
+        current.sort(function(a, b){ return order.indexOf(a) - order.indexOf(b); });
+        // If all three are enabled, remove this GPU from the map (use default)
+        if (current.length === 3) {
+            delete mm[gpuId];
+        } else {
+            mm[gpuId] = current;
+        }
+        var parts = [];
+        for (var id in mm) parts.push(id + ":" + mm[id].join(","));
+        cfg_gpuMetrics = parts.join("|");
+    }
+
     property string cfg_metricOrder: "cpu,ram,temp,gpu,bat,pwr,net"
     property bool cfg_mergeCpuTemp: false
     property bool cfg_mergeCpuFreq: false
     property bool cfg_mergeBatPwr: false
     property bool cfg_splitGpu: false
-    property bool cfg_showGpuVram: true
-    property bool cfg_showGpuUsage: true
-    property bool cfg_showGpuTemp: true
+    property string cfg_gpuMetrics: ""
     property bool cfg_showCpuFreq: false
 
     property var ifaceList: ["auto"]
@@ -442,12 +487,15 @@ KCM.SimpleKCM {
                 model: metricsPage.discoveredGpus
 
                 delegate: ColumnLayout {
+                    id: gpuDelegate
                     required property var modelData
                     spacing: 2
                     Layout.fillWidth: true
 
+                    // Reactive per-GPU enabled metrics list
+                    property var _activeMetrics: metricsPage.gpuMetricsFor(modelData.id)
+
                     CheckBox {
-                        // Show detected GPU name (e.g. "GPU 1") or user-defined custom label
                         text: modelData.name
                         checked: {
                             if (!cfg_gpuSelection || cfg_gpuSelection === "")
@@ -457,7 +505,6 @@ KCM.SimpleKCM {
                             return cfg_gpuSelection.split(",").indexOf(modelData.id) >= 0;
                         }
                         onToggled: {
-                            // Expand current selection into an explicit id list
                             var ids;
                             if (!cfg_gpuSelection || cfg_gpuSelection === "") {
                                 ids = gpuSelectorRepeater.model.map(function(g) { return g.id; });
@@ -474,79 +521,63 @@ KCM.SimpleKCM {
                             var allIds = gpuSelectorRepeater.model.map(function(g) { return g.id; });
                             var allSelected = allIds.every(function(id) { return ids.indexOf(id) >= 0; });
                             if (allSelected)
-                                cfg_gpuSelection = "";        // default: all discovered
+                                cfg_gpuSelection = "";
                             else if (ids.length === 0)
-                                cfg_gpuSelection = "none";    // explicit: nothing polled
+                                cfg_gpuSelection = "none";
                             else
                                 cfg_gpuSelection = ids.join(",");
                         }
                     }
 
-                    // Custom label rename field
+                    // Label row
                     RowLayout {
                         Layout.fillWidth: true
                         Layout.leftMargin: Kirigami.Units.gridUnit + Kirigami.Units.smallSpacing
                         spacing: Kirigami.Units.smallSpacing
 
-                        Label {
-                            text: i18n("Label:")
-                            opacity: 0.8
-                        }
+                        Label { text: i18n("Label:"); opacity: 0.8 }
 
                         TextField {
                             Layout.fillWidth: true
-                            // Show current custom label or empty to let placeholder show
                             text: metricsPage.parseGpuLabels(cfg_gpuLabels)[modelData.id] || ""
                             placeholderText: modelData.name
                             onTextEdited: metricsPage.saveGpuLabel(modelData.id, text)
                         }
                     }
+
+                    // Per-GPU sub-metric toggles (at least one must stay enabled)
+                    RowLayout {
+                        Layout.fillWidth: true
+                        Layout.leftMargin: Kirigami.Units.gridUnit + Kirigami.Units.smallSpacing
+                        spacing: Kirigami.Units.largeSpacing
+
+                        Label { text: i18n("Show:"); opacity: 0.8 }
+
+                        CheckBox {
+                            text: i18n("Usage")
+                            checked: gpuDelegate._activeMetrics.indexOf("usage") >= 0
+                            // Disable when it is the only remaining checked item
+                            enabled: cfg_showGpu && !(checked && gpuDelegate._activeMetrics.length <= 1)
+                            onToggled: metricsPage.saveGpuMetric(gpuDelegate.modelData.id, "usage", checked)
+                        }
+
+                        CheckBox {
+                            text: i18n("VRAM")
+                            checked: gpuDelegate._activeMetrics.indexOf("vram") >= 0
+                            enabled: cfg_showGpu && !(checked && gpuDelegate._activeMetrics.length <= 1)
+                            onToggled: metricsPage.saveGpuMetric(gpuDelegate.modelData.id, "vram", checked)
+                        }
+
+                        CheckBox {
+                            text: i18n("Temp")
+                            checked: gpuDelegate._activeMetrics.indexOf("temp") >= 0
+                            enabled: cfg_showGpu && !(checked && gpuDelegate._activeMetrics.length <= 1)
+                            onToggled: metricsPage.saveGpuMetric(gpuDelegate.modelData.id, "temp", checked)
+                        }
+                    }
                 }
             }
         }
-
-        Kirigami.Separator {
-            Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: i18n("GPU Sub-metrics")
-            visible: cfg_showGpu
-        }
-
-        Label {
-            text: i18n("Choose which GPU metrics to display. Hiding a metric saves horizontal panel space.")
-            opacity: 0.7
-            font.italic: true
-            visible: cfg_showGpu
-            wrapMode: Text.WordWrap
-            Layout.maximumWidth: 300
-        }
-
-        CheckBox {
-            Kirigami.FormData.label: i18n("Usage:")
-            text: i18n("Show GPU usage (%)")
-            checked: cfg_showGpuUsage
-            enabled: cfg_showGpu
-            onToggled: cfg_showGpuUsage = checked
-            visible: cfg_showGpu
-        }
-
-        CheckBox {
-            Kirigami.FormData.label: i18n("VRAM:")
-            text: i18n("Show GPU VRAM usage")
-            checked: cfg_showGpuVram
-            enabled: cfg_showGpu
-            onToggled: cfg_showGpuVram = checked
-            visible: cfg_showGpu
-        }
-
-        CheckBox {
-            Kirigami.FormData.label: i18n("Temperature:")
-            text: i18n("Show GPU temperature")
-            checked: cfg_showGpuTemp
-            enabled: cfg_showGpu
-            onToggled: cfg_showGpuTemp = checked
-            visible: cfg_showGpu
-        }
-
 
         Kirigami.Separator {
             Kirigami.FormData.isSection: true

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -108,6 +108,7 @@ KCM.SimpleKCM {
     property bool cfg_mergeCpuFreq: false
     property bool cfg_mergeBatPwr: false
     property bool cfg_splitGpu: false
+    property bool cfg_showGpuVram: true
     property bool cfg_showCpuFreq: false
 
     property var ifaceList: ["auto"]
@@ -500,6 +501,24 @@ KCM.SimpleKCM {
                     }
                 }
             }
+        }
+
+        CheckBox {
+            Kirigami.FormData.label: i18n("VRAM usage:")
+            text: i18n("Show GPU VRAM usage")
+            checked: cfg_showGpuVram
+            enabled: cfg_showGpu
+            onToggled: cfg_showGpuVram = checked
+            visible: cfg_showGpu
+        }
+
+        Label {
+            text: i18n("Hides the VRAM used/total metric to save horizontal space on the panel.")
+            opacity: 0.7
+            font.italic: true
+            visible: cfg_showGpu
+            wrapMode: Text.WordWrap
+            Layout.maximumWidth: 300
         }
 
         Kirigami.Separator {

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -109,6 +109,8 @@ KCM.SimpleKCM {
     property bool cfg_mergeBatPwr: false
     property bool cfg_splitGpu: false
     property bool cfg_showGpuVram: true
+    property bool cfg_showGpuUsage: true
+    property bool cfg_showGpuTemp: true
     property bool cfg_showCpuFreq: false
 
     property var ifaceList: ["auto"]
@@ -503,8 +505,32 @@ KCM.SimpleKCM {
             }
         }
 
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: i18n("GPU Sub-metrics")
+            visible: cfg_showGpu
+        }
+
+        Label {
+            text: i18n("Choose which GPU metrics to display. Hiding a metric saves horizontal panel space.")
+            opacity: 0.7
+            font.italic: true
+            visible: cfg_showGpu
+            wrapMode: Text.WordWrap
+            Layout.maximumWidth: 300
+        }
+
         CheckBox {
-            Kirigami.FormData.label: i18n("VRAM usage:")
+            Kirigami.FormData.label: i18n("Usage:")
+            text: i18n("Show GPU usage (%)")
+            checked: cfg_showGpuUsage
+            enabled: cfg_showGpu
+            onToggled: cfg_showGpuUsage = checked
+            visible: cfg_showGpu
+        }
+
+        CheckBox {
+            Kirigami.FormData.label: i18n("VRAM:")
             text: i18n("Show GPU VRAM usage")
             checked: cfg_showGpuVram
             enabled: cfg_showGpu
@@ -512,14 +538,15 @@ KCM.SimpleKCM {
             visible: cfg_showGpu
         }
 
-        Label {
-            text: i18n("Hides the VRAM used/total metric to save horizontal space on the panel.")
-            opacity: 0.7
-            font.italic: true
+        CheckBox {
+            Kirigami.FormData.label: i18n("Temperature:")
+            text: i18n("Show GPU temperature")
+            checked: cfg_showGpuTemp
+            enabled: cfg_showGpu
+            onToggled: cfg_showGpuTemp = checked
             visible: cfg_showGpu
-            wrapMode: Text.WordWrap
-            Layout.maximumWidth: 300
         }
+
 
         Kirigami.Separator {
             Kirigami.FormData.isSection: true

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -40,6 +40,8 @@ PlasmoidItem {
     property bool mergeBatPwr: Plasmoid.configuration.mergeBatPwr
     property bool splitGpu: Plasmoid.configuration.splitGpu
     property bool showGpuVram: Plasmoid.configuration.showGpuVram
+    property bool showGpuUsage: Plasmoid.configuration.showGpuUsage
+    property bool showGpuTemp: Plasmoid.configuration.showGpuTemp
     property int iconSize: Plasmoid.configuration.iconSize
     property string cpuIcon: Plasmoid.configuration.cpuIcon
     property string ramIcon: Plasmoid.configuration.ramIcon
@@ -155,6 +157,8 @@ PlasmoidItem {
         gpuLabels: root.gpuLabels
         tempUnit: root.tempUnit
         showVram: root.showGpuVram
+        showUsage: root.showGpuUsage
+        showTemp: root.showGpuTemp
     }
 
     BatterySensors {
@@ -222,20 +226,20 @@ PlasmoidItem {
                             var gd = gpu.gpuDataList[g];
                             var label = (gd.name.length > 0 ? gd.name : gd.id) + ":";
                             if (root.splitGpu) {
-                                if (gd.usage) items.push({icon: root.gpuIcon, label: label, value: gd.usage, color: root.gpuColor});
+                                if (gd.usage && root.showGpuUsage) items.push({icon: root.gpuIcon, label: label, value: gd.usage, color: root.gpuColor});
                                 if (gd.vram && root.showGpuVram)  items.push({icon: root.gpuIcon, label: "VRAM:", value: gd.vram, color: root.baseTextColor});
-                                if (gd.temp)  items.push({icon: root.gpuIcon, label: "GTEMP:", value: gd.temp, color: root.gpuTempColor});
+                                if (gd.temp && root.showGpuTemp)  items.push({icon: root.gpuIcon, label: "GTEMP:", value: gd.temp, color: root.gpuTempColor});
                             } else {
                                 var segs2 = [];
-                                if (gd.usage) segs2.push({value: gd.usage, color: root.gpuColor});
+                                if (gd.usage && root.showGpuUsage) segs2.push({value: gd.usage, color: root.gpuColor});
                                 if (gd.vram && root.showGpuVram)  segs2.push({value: gd.vram,  color: root.baseTextColor});
-                                if (gd.temp)  segs2.push({value: gd.temp,  color: root.gpuTempColor});
+                                if (gd.temp && root.showGpuTemp)  segs2.push({value: gd.temp,  color: root.gpuTempColor});
                                 if (segs2.length > 0)
                                     items.push({icon: root.gpuIcon, label: label, segments: segs2, color: root.gpuColor});
                             }
                         }
                     } else if (root.splitGpu) {
-                        if (gpu.hasGpuUsageData)
+                        if (gpu.hasGpuUsageData && root.showGpuUsage)
                             items.push({icon: root.gpuIcon, label: "GPU:", value: gpu.gpuValue, color: root.gpuColor});
                         if (gpu.hasGpuVramData && root.showGpuVram)
                             items.push({
@@ -244,7 +248,7 @@ PlasmoidItem {
                                 value: gpu.gpuRamValue,
                                 color: root.baseTextColor
                             });
-                        if (gpu.hasGpuTempData)
+                        if (gpu.hasGpuTempData && root.showGpuTemp)
                             items.push({
                                 icon: root.gpuIcon,
                                 label: "GTEMP:",
@@ -253,11 +257,11 @@ PlasmoidItem {
                             });
                     } else {
                         var gpuSegs = [];
-                        if (gpu.hasGpuUsageData)
+                        if (gpu.hasGpuUsageData && root.showGpuUsage)
                             gpuSegs.push({value: gpu.gpuValue, color: root.gpuColor});
                         if (gpu.hasGpuVramData && root.showGpuVram)
                             gpuSegs.push({value: gpu.gpuRamValue, color: root.baseTextColor});
-                        if (gpu.hasGpuTempData)
+                        if (gpu.hasGpuTempData && root.showGpuTemp)
                             gpuSegs.push({value: gpu.gpuTempValue, color: root.gpuTempColor});
                         items.push({
                             icon: root.gpuIcon, label: "GPU:", segments: gpuSegs,
@@ -345,12 +349,12 @@ PlasmoidItem {
                         for (var g = 0; g < gpu.gpuDataList.length; g++) {
                             var gd = gpu.gpuDataList[g];
                             var label = gd.name || gd.id;
-                            if (gd.usage) items.push({label: label + " Usage", value: gd.usage, color: root.gpuColor});
+                            if (gd.usage && root.showGpuUsage) items.push({label: label + " Usage", value: gd.usage, color: root.gpuColor});
                             if (gd.vram && root.showGpuVram)  items.push({label: label + " VRAM",  value: gd.vram,  color: root.baseTextColor});
-                            if (gd.temp)  items.push({label: label + " Temp",  value: gd.temp,  color: root.gpuTempColor});
+                            if (gd.temp && root.showGpuTemp)  items.push({label: label + " Temp",  value: gd.temp,  color: root.gpuTempColor});
                         }
                     } else {
-                        if (gpu.hasGpuUsageData) items.push({
+                        if (gpu.hasGpuUsageData && root.showGpuUsage) items.push({
                             label: "GPU Usage", value: gpu.gpuValue,
                             color: root.gpuColor
                         });
@@ -358,7 +362,7 @@ PlasmoidItem {
                             label: "GPU VRAM", value: gpu.gpuRamValue,
                             color: root.baseTextColor
                         });
-                        if (gpu.hasGpuTempData) items.push({
+                        if (gpu.hasGpuTempData && root.showGpuTemp) items.push({
                             label: "GPU Temp", value: gpu.gpuTempValue,
                             color: root.gpuTempColor
                         });
@@ -406,13 +410,13 @@ PlasmoidItem {
                     for (var g = 0; g < gpu.gpuDataList.length; g++) {
                         var gd = gpu.gpuDataList[g];
                         var label = gd.name || gd.id;
-                        var vals = [gd.usage, root.showGpuVram ? gd.vram : "", gd.temp].filter(function(v) { return v; });
+                        var vals = [root.showGpuUsage ? gd.usage : "", root.showGpuVram ? gd.vram : "", root.showGpuTemp ? gd.temp : ""].filter(function(v) { return v; });
                         if (vals.length > 0) parts.push(label + ": " + vals.join(" "));
                     }
                 } else {
-                    if (gpu.hasGpuUsageData) parts.push("GPU: " + gpu.gpuValue);
+                    if (gpu.hasGpuUsageData && root.showGpuUsage) parts.push("GPU: " + gpu.gpuValue);
                     if (gpu.hasGpuVramData && root.showGpuVram) parts.push("VRAM: " + gpu.gpuRamValue);
-                    if (gpu.hasGpuTempData) parts.push("GPU TEMP: " + gpu.gpuTempValue);
+                    if (gpu.hasGpuTempData && root.showGpuTemp) parts.push("GPU TEMP: " + gpu.gpuTempValue);
                 }
             } else if (key === "bat" && root.showBattery && battery.batValue)
                 parts.push("BAT: " + battery.batValue);

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -39,9 +39,7 @@ PlasmoidItem {
     property bool showCpuFreq: Plasmoid.configuration.showCpuFreq
     property bool mergeBatPwr: Plasmoid.configuration.mergeBatPwr
     property bool splitGpu: Plasmoid.configuration.splitGpu
-    property bool showGpuVram: Plasmoid.configuration.showGpuVram
-    property bool showGpuUsage: Plasmoid.configuration.showGpuUsage
-    property bool showGpuTemp: Plasmoid.configuration.showGpuTemp
+    property string gpuMetrics: Plasmoid.configuration.gpuMetrics
     property int iconSize: Plasmoid.configuration.iconSize
     property string cpuIcon: Plasmoid.configuration.cpuIcon
     property string ramIcon: Plasmoid.configuration.ramIcon
@@ -156,9 +154,7 @@ PlasmoidItem {
         gpuSelection: root.gpuSelection
         gpuLabels: root.gpuLabels
         tempUnit: root.tempUnit
-        showVram: root.showGpuVram
-        showUsage: root.showGpuUsage
-        showTemp: root.showGpuTemp
+        gpuMetrics: root.gpuMetrics
     }
 
     BatterySensors {
@@ -226,29 +222,29 @@ PlasmoidItem {
                             var gd = gpu.gpuDataList[g];
                             var label = (gd.name.length > 0 ? gd.name : gd.id) + ":";
                             if (root.splitGpu) {
-                                if (gd.usage && root.showGpuUsage) items.push({icon: root.gpuIcon, label: label, value: gd.usage, color: root.gpuColor});
-                                if (gd.vram && root.showGpuVram)  items.push({icon: root.gpuIcon, label: "VRAM:", value: gd.vram, color: root.baseTextColor});
-                                if (gd.temp && root.showGpuTemp)  items.push({icon: root.gpuIcon, label: "GTEMP:", value: gd.temp, color: root.gpuTempColor});
+                                if (gd.usage) items.push({icon: root.gpuIcon, label: label, value: gd.usage, color: root.gpuColor});
+                                if (gd.vram)  items.push({icon: root.gpuIcon, label: "VRAM:", value: gd.vram, color: root.baseTextColor});
+                                if (gd.temp)  items.push({icon: root.gpuIcon, label: "GTEMP:", value: gd.temp, color: root.gpuTempColor});
                             } else {
                                 var segs2 = [];
-                                if (gd.usage && root.showGpuUsage) segs2.push({value: gd.usage, color: root.gpuColor});
-                                if (gd.vram && root.showGpuVram)  segs2.push({value: gd.vram,  color: root.baseTextColor});
-                                if (gd.temp && root.showGpuTemp)  segs2.push({value: gd.temp,  color: root.gpuTempColor});
+                                if (gd.usage) segs2.push({value: gd.usage, color: root.gpuColor});
+                                if (gd.vram)  segs2.push({value: gd.vram,  color: root.baseTextColor});
+                                if (gd.temp)  segs2.push({value: gd.temp,  color: root.gpuTempColor});
                                 if (segs2.length > 0)
                                     items.push({icon: root.gpuIcon, label: label, segments: segs2, color: root.gpuColor});
                             }
                         }
                     } else if (root.splitGpu) {
-                        if (gpu.hasGpuUsageData && root.showGpuUsage)
+                        if (gpu.hasGpuUsageData)
                             items.push({icon: root.gpuIcon, label: "GPU:", value: gpu.gpuValue, color: root.gpuColor});
-                        if (gpu.hasGpuVramData && root.showGpuVram)
+                        if (gpu.hasGpuVramData)
                             items.push({
                                 icon: root.gpuIcon,
                                 label: "VRAM:",
                                 value: gpu.gpuRamValue,
                                 color: root.baseTextColor
                             });
-                        if (gpu.hasGpuTempData && root.showGpuTemp)
+                        if (gpu.hasGpuTempData)
                             items.push({
                                 icon: root.gpuIcon,
                                 label: "GTEMP:",
@@ -257,11 +253,11 @@ PlasmoidItem {
                             });
                     } else {
                         var gpuSegs = [];
-                        if (gpu.hasGpuUsageData && root.showGpuUsage)
+                        if (gpu.hasGpuUsageData)
                             gpuSegs.push({value: gpu.gpuValue, color: root.gpuColor});
-                        if (gpu.hasGpuVramData && root.showGpuVram)
+                        if (gpu.hasGpuVramData)
                             gpuSegs.push({value: gpu.gpuRamValue, color: root.baseTextColor});
-                        if (gpu.hasGpuTempData && root.showGpuTemp)
+                        if (gpu.hasGpuTempData)
                             gpuSegs.push({value: gpu.gpuTempValue, color: root.gpuTempColor});
                         items.push({
                             icon: root.gpuIcon, label: "GPU:", segments: gpuSegs,
@@ -349,20 +345,20 @@ PlasmoidItem {
                         for (var g = 0; g < gpu.gpuDataList.length; g++) {
                             var gd = gpu.gpuDataList[g];
                             var label = gd.name || gd.id;
-                            if (gd.usage && root.showGpuUsage) items.push({label: label + " Usage", value: gd.usage, color: root.gpuColor});
-                            if (gd.vram && root.showGpuVram)  items.push({label: label + " VRAM",  value: gd.vram,  color: root.baseTextColor});
-                            if (gd.temp && root.showGpuTemp)  items.push({label: label + " Temp",  value: gd.temp,  color: root.gpuTempColor});
+                            if (gd.usage) items.push({label: label + " Usage", value: gd.usage, color: root.gpuColor});
+                            if (gd.vram)  items.push({label: label + " VRAM",  value: gd.vram,  color: root.baseTextColor});
+                            if (gd.temp)  items.push({label: label + " Temp",  value: gd.temp,  color: root.gpuTempColor});
                         }
                     } else {
-                        if (gpu.hasGpuUsageData && root.showGpuUsage) items.push({
+                        if (gpu.hasGpuUsageData) items.push({
                             label: "GPU Usage", value: gpu.gpuValue,
                             color: root.gpuColor
                         });
-                        if (gpu.hasGpuVramData && root.showGpuVram) items.push({
+                        if (gpu.hasGpuVramData) items.push({
                             label: "GPU VRAM", value: gpu.gpuRamValue,
                             color: root.baseTextColor
                         });
-                        if (gpu.hasGpuTempData && root.showGpuTemp) items.push({
+                        if (gpu.hasGpuTempData) items.push({
                             label: "GPU Temp", value: gpu.gpuTempValue,
                             color: root.gpuTempColor
                         });
@@ -410,13 +406,13 @@ PlasmoidItem {
                     for (var g = 0; g < gpu.gpuDataList.length; g++) {
                         var gd = gpu.gpuDataList[g];
                         var label = gd.name || gd.id;
-                        var vals = [root.showGpuUsage ? gd.usage : "", root.showGpuVram ? gd.vram : "", root.showGpuTemp ? gd.temp : ""].filter(function(v) { return v; });
+                        var vals = [gd.usage, gd.vram, gd.temp].filter(function(v) { return v; });
                         if (vals.length > 0) parts.push(label + ": " + vals.join(" "));
                     }
                 } else {
-                    if (gpu.hasGpuUsageData && root.showGpuUsage) parts.push("GPU: " + gpu.gpuValue);
-                    if (gpu.hasGpuVramData && root.showGpuVram) parts.push("VRAM: " + gpu.gpuRamValue);
-                    if (gpu.hasGpuTempData && root.showGpuTemp) parts.push("GPU TEMP: " + gpu.gpuTempValue);
+                    if (gpu.hasGpuUsageData) parts.push("GPU: " + gpu.gpuValue);
+                    if (gpu.hasGpuVramData) parts.push("VRAM: " + gpu.gpuRamValue);
+                    if (gpu.hasGpuTempData) parts.push("GPU TEMP: " + gpu.gpuTempValue);
                 }
             } else if (key === "bat" && root.showBattery && battery.batValue)
                 parts.push("BAT: " + battery.batValue);

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -39,6 +39,7 @@ PlasmoidItem {
     property bool showCpuFreq: Plasmoid.configuration.showCpuFreq
     property bool mergeBatPwr: Plasmoid.configuration.mergeBatPwr
     property bool splitGpu: Plasmoid.configuration.splitGpu
+    property bool showGpuVram: Plasmoid.configuration.showGpuVram
     property int iconSize: Plasmoid.configuration.iconSize
     property string cpuIcon: Plasmoid.configuration.cpuIcon
     property string ramIcon: Plasmoid.configuration.ramIcon
@@ -153,6 +154,7 @@ PlasmoidItem {
         gpuSelection: root.gpuSelection
         gpuLabels: root.gpuLabels
         tempUnit: root.tempUnit
+        showVram: root.showGpuVram
     }
 
     BatterySensors {
@@ -221,12 +223,12 @@ PlasmoidItem {
                             var label = (gd.name.length > 0 ? gd.name : gd.id) + ":";
                             if (root.splitGpu) {
                                 if (gd.usage) items.push({icon: root.gpuIcon, label: label, value: gd.usage, color: root.gpuColor});
-                                if (gd.vram)  items.push({icon: root.gpuIcon, label: "VRAM:", value: gd.vram, color: root.baseTextColor});
+                                if (gd.vram && root.showGpuVram)  items.push({icon: root.gpuIcon, label: "VRAM:", value: gd.vram, color: root.baseTextColor});
                                 if (gd.temp)  items.push({icon: root.gpuIcon, label: "GTEMP:", value: gd.temp, color: root.gpuTempColor});
                             } else {
                                 var segs2 = [];
                                 if (gd.usage) segs2.push({value: gd.usage, color: root.gpuColor});
-                                if (gd.vram)  segs2.push({value: gd.vram,  color: root.baseTextColor});
+                                if (gd.vram && root.showGpuVram)  segs2.push({value: gd.vram,  color: root.baseTextColor});
                                 if (gd.temp)  segs2.push({value: gd.temp,  color: root.gpuTempColor});
                                 if (segs2.length > 0)
                                     items.push({icon: root.gpuIcon, label: label, segments: segs2, color: root.gpuColor});
@@ -235,7 +237,7 @@ PlasmoidItem {
                     } else if (root.splitGpu) {
                         if (gpu.hasGpuUsageData)
                             items.push({icon: root.gpuIcon, label: "GPU:", value: gpu.gpuValue, color: root.gpuColor});
-                        if (gpu.hasGpuVramData)
+                        if (gpu.hasGpuVramData && root.showGpuVram)
                             items.push({
                                 icon: root.gpuIcon,
                                 label: "VRAM:",
@@ -253,7 +255,7 @@ PlasmoidItem {
                         var gpuSegs = [];
                         if (gpu.hasGpuUsageData)
                             gpuSegs.push({value: gpu.gpuValue, color: root.gpuColor});
-                        if (gpu.hasGpuVramData)
+                        if (gpu.hasGpuVramData && root.showGpuVram)
                             gpuSegs.push({value: gpu.gpuRamValue, color: root.baseTextColor});
                         if (gpu.hasGpuTempData)
                             gpuSegs.push({value: gpu.gpuTempValue, color: root.gpuTempColor});
@@ -344,7 +346,7 @@ PlasmoidItem {
                             var gd = gpu.gpuDataList[g];
                             var label = gd.name || gd.id;
                             if (gd.usage) items.push({label: label + " Usage", value: gd.usage, color: root.gpuColor});
-                            if (gd.vram)  items.push({label: label + " VRAM",  value: gd.vram,  color: root.baseTextColor});
+                            if (gd.vram && root.showGpuVram)  items.push({label: label + " VRAM",  value: gd.vram,  color: root.baseTextColor});
                             if (gd.temp)  items.push({label: label + " Temp",  value: gd.temp,  color: root.gpuTempColor});
                         }
                     } else {
@@ -352,7 +354,7 @@ PlasmoidItem {
                             label: "GPU Usage", value: gpu.gpuValue,
                             color: root.gpuColor
                         });
-                        if (gpu.hasGpuVramData) items.push({
+                        if (gpu.hasGpuVramData && root.showGpuVram) items.push({
                             label: "GPU VRAM", value: gpu.gpuRamValue,
                             color: root.baseTextColor
                         });
@@ -404,12 +406,12 @@ PlasmoidItem {
                     for (var g = 0; g < gpu.gpuDataList.length; g++) {
                         var gd = gpu.gpuDataList[g];
                         var label = gd.name || gd.id;
-                        var vals = [gd.usage, gd.vram, gd.temp].filter(function(v) { return v; });
+                        var vals = [gd.usage, root.showGpuVram ? gd.vram : "", gd.temp].filter(function(v) { return v; });
                         if (vals.length > 0) parts.push(label + ": " + vals.join(" "));
                     }
                 } else {
                     if (gpu.hasGpuUsageData) parts.push("GPU: " + gpu.gpuValue);
-                    if (gpu.hasGpuVramData) parts.push("VRAM: " + gpu.gpuRamValue);
+                    if (gpu.hasGpuVramData && root.showGpuVram) parts.push("VRAM: " + gpu.gpuRamValue);
                     if (gpu.hasGpuTempData) parts.push("GPU TEMP: " + gpu.gpuTempValue);
                 }
             } else if (key === "bat" && root.showBattery && battery.batValue)

--- a/contents/ui/sensors/GpuSensors.qml
+++ b/contents/ui/sensors/GpuSensors.qml
@@ -16,6 +16,9 @@ Item {
     // Temperature unit: "C" (default) or "F"
     property string tempUnit: "C"
 
+    // Whether to poll and display VRAM usage
+    property bool showVram: true
+
     // List of { id: "gpu0", name: "GPU 1" } derived from SensorTreeModel (no polling)
     readonly property var discoveredGpus: _discovered
     property var _discovered: []
@@ -26,7 +29,12 @@ Item {
     readonly property string gpuValue:     _usageStr
     readonly property string gpuRamValue:  _vramStr
     readonly property string gpuTempValue: _tempStr
-    readonly property string gpuDisplayValue: [_usageStr, _vramStr, _tempStr].filter(function(v){return v;}).join(" ")
+    readonly property string gpuDisplayValue: {
+        var parts = [_usageStr];
+        if (showVram) parts.push(_vramStr);
+        parts.push(_tempStr);
+        return parts.filter(function(v){return v;}).join(" ");
+    }
     readonly property bool hasGpuData:      gpuDisplayValue.length > 0
     readonly property bool hasGpuUsageData: _usageStr.length > 0
     readonly property bool hasGpuVramData:  _vramStr.length > 0
@@ -114,8 +122,10 @@ Item {
         for (var i = 0; i < _activeIds.length; i++) {
             var g = _activeIds[i];
             ids.push("gpu/" + g + "/usage");
-            ids.push("gpu/" + g + "/usedVram");
-            ids.push("gpu/" + g + "/totalVram");
+            if (showVram) {
+                ids.push("gpu/" + g + "/usedVram");
+                ids.push("gpu/" + g + "/totalVram");
+            }
             ids.push("gpu/" + g + "/temperature");
         }
         return ids;
@@ -173,7 +183,7 @@ Item {
 
             var uStr = isNaN(uVal) ? "" : Math.round(uVal) + "%";
             var vStr = "";
-            if (!isNaN(vuVal) && !isNaN(vtVal) && vtVal > 0 && vuVal >= 0)
+            if (showVram && !isNaN(vuVal) && !isNaN(vtVal) && vtVal > 0 && vuVal >= 0)
                 vStr = Utils.formatBytes(vuVal) + "/" + Utils.formatBytes(vtVal) + "G";
             // tVal === 0 is ksystemstats' null sentinel for iGPU: no hwmon node exists,
             // so the driver reports exactly 0. No real GPU can be at or below 0°C.
@@ -185,7 +195,7 @@ Item {
                            tempNumber:  (isNaN(tVal) || tVal <= 0) ? NaN : tVal });
 
             if (!isNaN(uVal)) { totalUsage += uVal; usageCount++; }
-            if (!isNaN(vuVal) && !isNaN(vtVal) && vtVal > 0 && vuVal >= 0) {
+            if (showVram && !isNaN(vuVal) && !isNaN(vtVal) && vtVal > 0 && vuVal >= 0) {
                 totalVramUsed  += vuVal;
                 totalVramTotal += vtVal;
                 hasVram = true;
@@ -203,8 +213,9 @@ Item {
         _tempStr  = isNaN(maxTemp) ? "" : Utils.formatTemp(maxTemp, tempUnit);
     }
 
-    // Re-aggregate when labels, selection, or unit change so panel updates immediately
+    // Re-aggregate when labels, selection, unit, or vram visibility change so panel updates immediately
     onGpuLabelsChanged:    aggregate()
     onGpuSelectionChanged: aggregate()
     onTempUnitChanged:     aggregate()
+    onShowVramChanged:     aggregate()
 }

--- a/contents/ui/sensors/GpuSensors.qml
+++ b/contents/ui/sensors/GpuSensors.qml
@@ -10,20 +10,15 @@ Item {
     // Comma-separated selected GPU IDs e.g. "gpu0,gpu1". Empty = all discovered.
     property string gpuSelection: ""
 
-    // User-defined labels: "gpu0:My iGPU,gpu1:dGPU". Empty string = use default "GPU N" name.
+    // User-defined labels: "gpu0:My iGPU|gpu1:dGPU". Empty string = use default "GPU N" name.
     property string gpuLabels: ""
 
     // Temperature unit: "C" (default) or "F"
     property string tempUnit: "C"
 
-    // Whether to poll and display VRAM usage
-    property bool showVram: true
-
-    // Whether to display GPU usage percentage
-    property bool showUsage: true
-
-    // Whether to display GPU temperature
-    property bool showTemp: true
+    // Per-GPU sub-metric visibility: "gpu0:usage,vram|gpu1:usage,temp"
+    // Empty string (default) = all three sub-metrics enabled for every GPU.
+    property string gpuMetrics: ""
 
     // List of { id: "gpu0", name: "GPU 1" } derived from SensorTreeModel (no polling)
     readonly property var discoveredGpus: _discovered
@@ -35,17 +30,12 @@ Item {
     readonly property string gpuValue:     _usageStr
     readonly property string gpuRamValue:  _vramStr
     readonly property string gpuTempValue: _tempStr
-    readonly property string gpuDisplayValue: {
-        var parts = [];
-        if (showUsage) parts.push(_usageStr);
-        if (showVram)  parts.push(_vramStr);
-        if (showTemp)  parts.push(_tempStr);
-        return parts.filter(function(v){return v;}).join(" ");
-    }
+    readonly property string gpuDisplayValue:
+        [_usageStr, _vramStr, _tempStr].filter(function(v){return v;}).join(" ")
     readonly property bool hasGpuData:      gpuDisplayValue.length > 0
-    readonly property bool hasGpuUsageData: showUsage && _usageStr.length > 0
-    readonly property bool hasGpuVramData:  showVram  && _vramStr.length > 0
-    readonly property bool hasGpuTempData:  showTemp  && _tempStr.length > 0
+    readonly property bool hasGpuUsageData: _usageStr.length > 0
+    readonly property bool hasGpuVramData:  _vramStr.length  > 0
+    readonly property bool hasGpuTempData:  _tempStr.length  > 0
 
     // Per-GPU list for multi display: [{ id, name, usage, vram, temp, usageNumber, tempNumber }]
     readonly property var gpuDataList: _dataList
@@ -83,6 +73,30 @@ Item {
         return result;
     }
 
+    // Parse "gpu0:usage,vram|gpu1:usage,temp" → { gpu0: ["usage","vram"], gpu1: ["usage","temp"] }
+    // Missing GPU or empty string → default all three enabled.
+    function parseGpuMetrics(str) {
+        var result = {};
+        if (!str) return result;
+        var pairs = str.split("|");
+        for (var i = 0; i < pairs.length; i++) {
+            var sep = pairs[i].indexOf(":");
+            if (sep <= 0) continue;
+            var id = pairs[i].substring(0, sep);
+            var metrics = pairs[i].substring(sep + 1).split(",")
+                .filter(function(m){ return m === "usage" || m === "vram" || m === "temp"; });
+            if (metrics.length > 0) result[id] = metrics;
+        }
+        return result;
+    }
+
+    // Return enabled sub-metric list for a specific GPU (["usage","vram","temp"] if unconfigured)
+    function gpuMetricsFor(gpuId, metricsMap) {
+        return (metricsMap[gpuId] && metricsMap[gpuId].length > 0)
+            ? metricsMap[gpuId]
+            : ["usage", "vram", "temp"];
+    }
+
     function refreshDiscovered() {
         var found = [];
         for (var row = 0; row < flatSensors.rowCount(); row++) {
@@ -97,43 +111,47 @@ Item {
         if (JSON.stringify(found) !== JSON.stringify(_discovered)) {
             _discovered = found;
             if (typeof Plasmoid !== "undefined" && Plasmoid.configuration)
-                Plasmoid.configuration.gpuDiscovered = found.map(function(g){ return g.id + ":" + g.name; }).join(",");
+                Plasmoid.configuration.gpuDiscovered =
+                    found.map(function(g){ return g.id + ":" + g.name; }).join(",");
         }
     }
 
     Connections {
         target: flatSensors
-        function onRowsInserted()    { root.refreshDiscovered(); }
-        function onRowsRemoved()     { root.refreshDiscovered(); }
-        function onModelReset()      { root.refreshDiscovered(); }
-        function onDataChanged()     { root.refreshDiscovered(); }
+        function onRowsInserted() { root.refreshDiscovered(); }
+        function onRowsRemoved()  { root.refreshDiscovered(); }
+        function onModelReset()   { root.refreshDiscovered(); }
+        function onDataChanged()  { root.refreshDiscovered(); }
     }
 
     Component.onCompleted: refreshDiscovered()
 
     // -------------------------------------------------------------------------
-    // Step 2: Compute active sensor IDs from user selection
+    // Step 2: Compute active sensor IDs — per GPU, only poll enabled sub-metrics
     // -------------------------------------------------------------------------
 
     readonly property var _activeIds: {
-        // "" (default) → all discovered; "none" → user explicitly deselected everything
         if (!gpuSelection || gpuSelection === "")
             return _discovered.map(function(g){ return g.id; });
         if (gpuSelection === "none")
             return [];
-        return gpuSelection.split(",").map(function(s){ return s.trim(); }).filter(function(s){ return s.length > 0; });
+        return gpuSelection.split(",")
+            .map(function(s){ return s.trim(); })
+            .filter(function(s){ return s.length > 0; });
     }
 
     readonly property var _activeSensorIds: {
         var ids = [];
+        var mm = parseGpuMetrics(gpuMetrics);
         for (var i = 0; i < _activeIds.length; i++) {
             var g = _activeIds[i];
-            if (showUsage) ids.push("gpu/" + g + "/usage");
-            if (showVram) {
+            var m = gpuMetricsFor(g, mm);
+            if (m.indexOf("usage") >= 0) ids.push("gpu/" + g + "/usage");
+            if (m.indexOf("vram")  >= 0) {
                 ids.push("gpu/" + g + "/usedVram");
                 ids.push("gpu/" + g + "/totalVram");
             }
-            if (showTemp) ids.push("gpu/" + g + "/temperature");
+            if (m.indexOf("temp")  >= 0) ids.push("gpu/" + g + "/temperature");
         }
         return ids;
     }
@@ -168,6 +186,7 @@ Item {
     function aggregate() {
         var ids = _activeIds;
         var customLabels = parseGpuLabels(gpuLabels);
+        var mm = parseGpuMetrics(gpuMetrics);
         var newList = [];
         var totalUsage = 0, usageCount = 0;
         var totalVramUsed = 0, totalVramTotal = 0, hasVram = false;
@@ -175,6 +194,10 @@ Item {
 
         for (var i = 0; i < ids.length; i++) {
             var g = ids[i];
+            var m = gpuMetricsFor(g, mm);
+            var showU = m.indexOf("usage") >= 0;
+            var showV = m.indexOf("vram")  >= 0;
+            var showT = m.indexOf("temp")  >= 0;
 
             // Resolve display name: custom label > default name > fallback
             var hwName = "GPU " + (i + 1);
@@ -183,48 +206,45 @@ Item {
             }
             var name = customLabels[g] || hwName;
 
-            var uVal  = _modelValue("gpu/" + g + "/usage");
-            var vuVal = _modelValue("gpu/" + g + "/usedVram");
-            var vtVal = _modelValue("gpu/" + g + "/totalVram");
-            var tVal  = _modelValue("gpu/" + g + "/temperature");
+            var uVal  = showU ? _modelValue("gpu/" + g + "/usage")       : NaN;
+            var vuVal = showV ? _modelValue("gpu/" + g + "/usedVram")     : NaN;
+            var vtVal = showV ? _modelValue("gpu/" + g + "/totalVram")    : NaN;
+            var tVal  = showT ? _modelValue("gpu/" + g + "/temperature")  : NaN;
 
-            var uStr = showUsage && !isNaN(uVal) ? Math.round(uVal) + "%" : "";
+            var uStr = !isNaN(uVal) ? Math.round(uVal) + "%" : "";
             var vStr = "";
-            if (showVram && !isNaN(vuVal) && !isNaN(vtVal) && vtVal > 0 && vuVal >= 0)
+            if (!isNaN(vuVal) && !isNaN(vtVal) && vtVal > 0 && vuVal >= 0)
                 vStr = Utils.formatBytes(vuVal) + "/" + Utils.formatBytes(vtVal) + "G";
-            // tVal === 0 is ksystemstats' null sentinel for iGPU: no hwmon node exists,
-            // so the driver reports exactly 0. No real GPU can be at or below 0°C.
-            var tStr = (showTemp && !isNaN(tVal) && tVal > 0) ? Utils.formatTemp(tVal, tempUnit) : "";
+            // tVal === 0 is ksystemstats' null sentinel for iGPU (no hwmon node)
+            var tStr = (!isNaN(tVal) && tVal > 0) ? Utils.formatTemp(tVal, tempUnit) : "";
 
             newList.push({ id: g, name: name,
                            usage: uStr, vram: vStr, temp: tStr,
-                           usageNumber: (showUsage && !isNaN(uVal)) ? uVal : NaN,
-                           tempNumber:  (showTemp  && !isNaN(tVal) && tVal > 0) ? tVal : NaN });
+                           usageNumber: !isNaN(uVal) ? uVal : NaN,
+                           tempNumber:  (!isNaN(tVal) && tVal > 0) ? tVal : NaN });
 
-            if (showUsage && !isNaN(uVal)) { totalUsage += uVal; usageCount++; }
-            if (showVram && !isNaN(vuVal) && !isNaN(vtVal) && vtVal > 0 && vuVal >= 0) {
+            if (!isNaN(uVal)) { totalUsage += uVal; usageCount++; }
+            if (!isNaN(vuVal) && !isNaN(vtVal) && vtVal > 0 && vuVal >= 0) {
                 totalVramUsed  += vuVal;
                 totalVramTotal += vtVal;
                 hasVram = true;
             }
-            if (showTemp && !isNaN(tVal) && tVal > 0 && (isNaN(maxTemp) || tVal > maxTemp)) maxTemp = tVal;
+            if (!isNaN(tVal) && tVal > 0 && (isNaN(maxTemp) || tVal > maxTemp)) maxTemp = tVal;
         }
 
         _dataList = newList;
 
-        _usageNum = (showUsage && usageCount > 0) ? totalUsage / usageCount : NaN;
-        _usageStr = (showUsage && usageCount > 0) ? Math.round(_usageNum) + "%" : "";
-        _vramStr  = (showVram && hasVram && totalVramTotal > 0)
+        _usageNum = usageCount > 0 ? totalUsage / usageCount : NaN;
+        _usageStr = usageCount > 0 ? Math.round(_usageNum) + "%" : "";
+        _vramStr  = (hasVram && totalVramTotal > 0)
                     ? Utils.formatBytes(totalVramUsed) + "/" + Utils.formatBytes(totalVramTotal) + "G" : "";
-        _tempNum  = (showTemp && !isNaN(maxTemp)) ? maxTemp : NaN;
-        _tempStr  = (showTemp && !isNaN(maxTemp)) ? Utils.formatTemp(maxTemp, tempUnit) : "";
+        _tempNum  = !isNaN(maxTemp) ? maxTemp : NaN;
+        _tempStr  = !isNaN(maxTemp) ? Utils.formatTemp(maxTemp, tempUnit) : "";
     }
 
-    // Re-aggregate when any visibility flag, labels, selection, or unit changes
+    // Re-aggregate when gpuMetrics, labels, selection, or unit change
+    onGpuMetricsChanged:   aggregate()
     onGpuLabelsChanged:    aggregate()
     onGpuSelectionChanged: aggregate()
     onTempUnitChanged:     aggregate()
-    onShowVramChanged:     aggregate()
-    onShowUsageChanged:    aggregate()
-    onShowTempChanged:     aggregate()
 }

--- a/contents/ui/sensors/GpuSensors.qml
+++ b/contents/ui/sensors/GpuSensors.qml
@@ -19,6 +19,12 @@ Item {
     // Whether to poll and display VRAM usage
     property bool showVram: true
 
+    // Whether to display GPU usage percentage
+    property bool showUsage: true
+
+    // Whether to display GPU temperature
+    property bool showTemp: true
+
     // List of { id: "gpu0", name: "GPU 1" } derived from SensorTreeModel (no polling)
     readonly property var discoveredGpus: _discovered
     property var _discovered: []
@@ -30,15 +36,16 @@ Item {
     readonly property string gpuRamValue:  _vramStr
     readonly property string gpuTempValue: _tempStr
     readonly property string gpuDisplayValue: {
-        var parts = [_usageStr];
-        if (showVram) parts.push(_vramStr);
-        parts.push(_tempStr);
+        var parts = [];
+        if (showUsage) parts.push(_usageStr);
+        if (showVram)  parts.push(_vramStr);
+        if (showTemp)  parts.push(_tempStr);
         return parts.filter(function(v){return v;}).join(" ");
     }
     readonly property bool hasGpuData:      gpuDisplayValue.length > 0
-    readonly property bool hasGpuUsageData: _usageStr.length > 0
-    readonly property bool hasGpuVramData:  _vramStr.length > 0
-    readonly property bool hasGpuTempData:  _tempStr.length > 0
+    readonly property bool hasGpuUsageData: showUsage && _usageStr.length > 0
+    readonly property bool hasGpuVramData:  showVram  && _vramStr.length > 0
+    readonly property bool hasGpuTempData:  showTemp  && _tempStr.length > 0
 
     // Per-GPU list for multi display: [{ id, name, usage, vram, temp, usageNumber, tempNumber }]
     readonly property var gpuDataList: _dataList
@@ -121,12 +128,12 @@ Item {
         var ids = [];
         for (var i = 0; i < _activeIds.length; i++) {
             var g = _activeIds[i];
-            ids.push("gpu/" + g + "/usage");
+            if (showUsage) ids.push("gpu/" + g + "/usage");
             if (showVram) {
                 ids.push("gpu/" + g + "/usedVram");
                 ids.push("gpu/" + g + "/totalVram");
             }
-            ids.push("gpu/" + g + "/temperature");
+            if (showTemp) ids.push("gpu/" + g + "/temperature");
         }
         return ids;
     }
@@ -181,41 +188,43 @@ Item {
             var vtVal = _modelValue("gpu/" + g + "/totalVram");
             var tVal  = _modelValue("gpu/" + g + "/temperature");
 
-            var uStr = isNaN(uVal) ? "" : Math.round(uVal) + "%";
+            var uStr = showUsage && !isNaN(uVal) ? Math.round(uVal) + "%" : "";
             var vStr = "";
             if (showVram && !isNaN(vuVal) && !isNaN(vtVal) && vtVal > 0 && vuVal >= 0)
                 vStr = Utils.formatBytes(vuVal) + "/" + Utils.formatBytes(vtVal) + "G";
             // tVal === 0 is ksystemstats' null sentinel for iGPU: no hwmon node exists,
             // so the driver reports exactly 0. No real GPU can be at or below 0°C.
-            var tStr = (isNaN(tVal) || tVal <= 0) ? "" : Utils.formatTemp(tVal, tempUnit);
+            var tStr = (showTemp && !isNaN(tVal) && tVal > 0) ? Utils.formatTemp(tVal, tempUnit) : "";
 
             newList.push({ id: g, name: name,
                            usage: uStr, vram: vStr, temp: tStr,
-                           usageNumber: isNaN(uVal) ? NaN : uVal,
-                           tempNumber:  (isNaN(tVal) || tVal <= 0) ? NaN : tVal });
+                           usageNumber: (showUsage && !isNaN(uVal)) ? uVal : NaN,
+                           tempNumber:  (showTemp  && !isNaN(tVal) && tVal > 0) ? tVal : NaN });
 
-            if (!isNaN(uVal)) { totalUsage += uVal; usageCount++; }
+            if (showUsage && !isNaN(uVal)) { totalUsage += uVal; usageCount++; }
             if (showVram && !isNaN(vuVal) && !isNaN(vtVal) && vtVal > 0 && vuVal >= 0) {
                 totalVramUsed  += vuVal;
                 totalVramTotal += vtVal;
                 hasVram = true;
             }
-            if (!isNaN(tVal) && tVal > 0 && (isNaN(maxTemp) || tVal > maxTemp)) maxTemp = tVal;
+            if (showTemp && !isNaN(tVal) && tVal > 0 && (isNaN(maxTemp) || tVal > maxTemp)) maxTemp = tVal;
         }
 
         _dataList = newList;
 
-        _usageNum = usageCount > 0 ? totalUsage / usageCount : NaN;
-        _usageStr = usageCount > 0 ? Math.round(_usageNum) + "%" : "";
-        _vramStr  = (hasVram && totalVramTotal > 0)
+        _usageNum = (showUsage && usageCount > 0) ? totalUsage / usageCount : NaN;
+        _usageStr = (showUsage && usageCount > 0) ? Math.round(_usageNum) + "%" : "";
+        _vramStr  = (showVram && hasVram && totalVramTotal > 0)
                     ? Utils.formatBytes(totalVramUsed) + "/" + Utils.formatBytes(totalVramTotal) + "G" : "";
-        _tempNum  = isNaN(maxTemp) ? NaN : maxTemp;
-        _tempStr  = isNaN(maxTemp) ? "" : Utils.formatTemp(maxTemp, tempUnit);
+        _tempNum  = (showTemp && !isNaN(maxTemp)) ? maxTemp : NaN;
+        _tempStr  = (showTemp && !isNaN(maxTemp)) ? Utils.formatTemp(maxTemp, tempUnit) : "";
     }
 
-    // Re-aggregate when labels, selection, unit, or vram visibility change so panel updates immediately
+    // Re-aggregate when any visibility flag, labels, selection, or unit changes
     onGpuLabelsChanged:    aggregate()
     onGpuSelectionChanged: aggregate()
     onTempUnitChanged:     aggregate()
     onShowVramChanged:     aggregate()
+    onShowUsageChanged:    aggregate()
+    onShowTempChanged:     aggregate()
 }


### PR DESCRIPTION
## Description

This PR introduces independent per-GPU sub-metric visibility controls (Usage, VRAM, and Temperature), replacing the global toggles. This allows users with multiple GPUs (e.g., an integrated GPU and a discrete GPU) to tailor the displayed metrics for each device separately.

### Key Changes:
- **Per-GPU Configuration:** Checks are now located inside each GPU’s setup box on the config page.
- **Minimum One Metric Enforced:** Checkboxes disable themselves if they are the last checked metric for that GPU, avoiding empty metric items (which should instead be turned off at the top level).
- **Resource Optimization:** Disabled sub-metrics are dropped from the underlying `SensorDataModel` to stop polling them.
- **Backwards Compatibility:** Default configuration values are preserved (all metrics shown if no custom metrics string is stored).

## Testing
- [x] Tested on KDE Plasma 6.6.5
- [x] Distro: Fedora Linux 43
- [x] Widget installs cleanly with `install.sh.`
- [x] Widget displays correctly in the panel

## Screenshots

<img width="345" height="42" alt="image" src="https://github.com/user-attachments/assets/a151e199-6517-4246-b173-7a55f59f6faf" />
<img width="950" height="639" alt="image" src="https://github.com/user-attachments/assets/fefa4951-775c-4efa-8c03-f6dce3b983e8" />
