### PR TITLE
feat: add 'None' display mode option

### DIFF
--- a/contents/ui/CompactView.qml
+++ b/contents/ui/CompactView.qml
@@ -179,6 +179,7 @@ RowLayout {
 
                 // Bottom: icon + label
                 RowLayout {
+                    visible: compactRow.useIcons || compactRow.useText
                     spacing: 2
                     Layout.alignment: Qt.AlignHCenter
 
@@ -192,7 +193,7 @@ RowLayout {
                     }
 
                     PlasmaComponents.Label {
-                        visible: compactRow.useText || !compactRow.useIcons
+                        visible: compactRow.useText
                         text: {
                             var lbl = itemData.label || "";
                             return lbl.endsWith(":") ? lbl.slice(0, -1) : lbl;

--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -17,9 +17,9 @@ KCM.SimpleKCM {
     property string cfg_tempUnit: "C"
     property string cfg_networkUnit: "bytes"
 
-    readonly property var displayModes: ["text", "icons", "icons+text"]
-    readonly property var displayModeLabels: [i18n("Text"), i18n("Icons"), i18n("Icons + Text")]
-    readonly property bool iconsEnabled: cfg_displayMode !== "text"
+    readonly property var displayModes: ["text", "icons", "icons+text", "none"]
+    readonly property var displayModeLabels: [i18n("Text"), i18n("Icons"), i18n("Icons + Text"), i18n("None")]
+    readonly property bool iconsEnabled: cfg_displayMode === "icons" || cfg_displayMode === "icons+text"
 
     readonly property var layoutTypes: ["horizontal", "vertical"]
     readonly property var layoutTypeLabels: [i18n("Horizontal"), i18n("Vertical")]


### PR DESCRIPTION
## Description

This pull request updates the display mode options and visibility logic for the compact view, adding a new "None" display mode and refining how icons and labels are shown. The main changes are grouped below by theme.

**Display Mode Options:**

* Added a new "none" option to the `displayModes` and `displayModeLabels` arrays in `configGeneral.qml`, allowing users to hide both icons and text.
* Updated the `iconsEnabled` logic to only enable icons when the display mode is "icons" or "icons+text", ensuring accurate state management.

**Visibility Logic Improvements:**

* Changed the `RowLayout` in `CompactView.qml` to only be visible if either icons or text are enabled, preventing empty UI elements when in "none" mode.
* Refined the label visibility condition so labels are only shown when text is enabled, matching the new display mode logic.
## Related Issue

Fixes #46 

## Testing

- [x] Tested on KDE Plasma 6.6.5
- [x] Distro: Fedora 43
- [x] Widget installs cleanly with `install.sh`
- [x] Widget displays correctly in the panel

## Screenshots

<img width="387" height="47" alt="image" src="https://github.com/user-attachments/assets/f92c7c91-c88b-40c9-a13d-382ed646f5af" />