### PR TITLE
feat: add standalone fan speed metrics

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -31,6 +31,9 @@
         <entry name="showDisk" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="showFan" type="Bool">
+            <default>false</default>
+        </entry>
         <entry name="compactShowCpu" type="Bool">
             <default>true</default>
         </entry>
@@ -53,6 +56,9 @@
             <default>true</default>
         </entry>
         <entry name="compactShowDisk" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="compactShowFan" type="Bool">
             <default>false</default>
         </entry>
         <entry name="networkInterface" type="String">
@@ -118,6 +124,9 @@
         <entry name="diskIcon" type="String">
             <default>drive-harddisk</default>
         </entry>
+        <entry name="fanIcon" type="String">
+            <default>fan</default>
+        </entry>
         <entry name="fontFamily" type="String">
             <default>monospace</default>
         </entry>
@@ -128,7 +137,7 @@
             <default>false</default>
         </entry>
         <entry name="metricOrder" type="String">
-            <default>cpu,ram,temp,gpu,bat,pwr,net,disk</default>
+            <default>cpu,ram,temp,gpu,bat,pwr,net,disk,fan</default>
         </entry>
         <entry name="updateInterval" type="Int">
             <default>2000</default>
@@ -195,6 +204,9 @@
         </entry>
         <entry name="networkUnit" type="String">
             <default>bytes</default>
+        </entry>
+        <entry name="fanUnit" type="String">
+            <default>rpm</default>
         </entry>
     </group>
 </kcfg>

--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -16,6 +16,7 @@ KCM.SimpleKCM {
     property string cfg_layoutType: "horizontal"
     property string cfg_tempUnit: "C"
     property string cfg_networkUnit: "bytes"
+    property string cfg_fanUnit: "rpm"
 
     readonly property var displayModes: ["text", "icons", "icons+text", "none"]
     readonly property var displayModeLabels: [i18n("Text"), i18n("Icons"), i18n("Icons + Text"), i18n("None")]
@@ -140,6 +141,14 @@ KCM.SimpleKCM {
             model: [i18n("Bytes  (KB, MB)"), i18n("Bits  (Kb, Mb)")]
             currentIndex: cfg_networkUnit === "bits" ? 1 : 0
             onActivated: cfg_networkUnit = (currentIndex === 1 ? "bits" : "bytes")
+        }
+
+        ComboBox {
+            id: fanUnitCombo
+            Kirigami.FormData.label: i18n("Fan Speed unit:")
+            model: [i18n("RPM"), i18n("Percentage (%)")]
+            currentIndex: cfg_fanUnit === "percent" ? 1 : 0
+            onActivated: cfg_fanUnit = (currentIndex === 1 ? "percent" : "rpm")
         }
     }
 }

--- a/contents/ui/configIcons.qml
+++ b/contents/ui/configIcons.qml
@@ -16,6 +16,7 @@ KCM.SimpleKCM {
     property string cfg_powerIcon: "battery-charging-60"
     property string cfg_networkIcon: "network-wireless"
     property string cfg_diskIcon: "drive-harddisk"
+    property string cfg_fanIcon: "fan"
 
     KIconThemes.IconDialog {
         id: cpuIconDialog
@@ -48,6 +49,10 @@ KCM.SimpleKCM {
     KIconThemes.IconDialog {
         id: diskIconDialog
         onIconNameChanged: if (iconName) cfg_diskIcon = iconName
+    }
+    KIconThemes.IconDialog {
+        id: fanIconDialog
+        onIconNameChanged: if (iconName) cfg_fanIcon = iconName
     }
 
     Kirigami.FormLayout {
@@ -100,6 +105,12 @@ KCM.SimpleKCM {
             Button { text: i18n("Change..."); onClicked: diskIconDialog.open(); icon.name: "document-edit" }
         }
 
+        RowLayout {
+            Kirigami.FormData.label: i18n("Fan:")
+            Kirigami.Icon { source: cfg_fanIcon; isMask: true; Layout.preferredWidth: 22; Layout.preferredHeight: 22 }
+            Button { text: i18n("Change..."); onClicked: fanIconDialog.open(); icon.name: "document-edit" }
+        }
+
         Button {
             icon.name: "edit-undo"
             text: i18n("Reset to defaults")
@@ -113,6 +124,7 @@ KCM.SimpleKCM {
                 cfg_powerIcon = "battery-charging-60";
                 cfg_networkIcon = "network-wireless";
                 cfg_diskIcon = "drive-harddisk";
+                cfg_fanIcon = "fan";
             }
         }
     }

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -19,6 +19,7 @@ KCM.SimpleKCM {
     property bool cfg_showPower
     property bool cfg_showNetwork
     property bool cfg_showDisk
+    property bool cfg_showFan
     property bool cfg_compactShowCpu
     property bool cfg_compactShowRam
     property bool cfg_compactShowTemp
@@ -27,6 +28,7 @@ KCM.SimpleKCM {
     property bool cfg_compactShowPower
     property bool cfg_compactShowNetwork
     property bool cfg_compactShowDisk
+    property bool cfg_compactShowFan
     property string cfg_networkInterface: "auto"
     property string cfg_batteryDevice
     property string cfg_gpuSelection: ""
@@ -166,7 +168,7 @@ KCM.SimpleKCM {
     }
 
     // --- Metric order helpers ---
-    readonly property var allKeys: ["cpu", "ram", "temp", "gpu", "bat", "pwr", "net", "disk"]
+    readonly property var allKeys: ["cpu", "ram", "temp", "gpu", "bat", "pwr", "net", "disk", "fan"]
 
     readonly property var metricMeta: ({
         "cpu":  { label: i18n("CPU usage"),         icon: "cpu" },
@@ -176,7 +178,8 @@ KCM.SimpleKCM {
         "bat":  { label: i18n("Battery status"),     icon: "battery-good" },
         "pwr":  { label: i18n("Power consumption"),  icon: "battery-charging-60" },
         "net":  { label: i18n("Network speed"),      icon: "network-wireless" },
-        "disk": { label: i18n("Disk I/O & temp"),    icon: "drive-harddisk" }
+        "disk": { label: i18n("Disk I/O & temp"),    icon: "drive-harddisk" },
+        "fan":  { label: i18n("Fan speed"),          icon: "fan" }
     })
 
     property var currentOrder: {
@@ -196,6 +199,7 @@ KCM.SimpleKCM {
             case "pwr":  return cfg_showPower;
             case "net":  return cfg_showNetwork;
             case "disk": return cfg_showDisk;
+            case "fan":  return cfg_showFan;
         }
         return false;
     }
@@ -210,6 +214,7 @@ KCM.SimpleKCM {
             case "pwr":  return cfg_compactShowPower;
             case "net":  return cfg_compactShowNetwork;
             case "disk": return cfg_compactShowDisk;
+            case "fan":  return cfg_compactShowFan;
         }
         return false;
     }
@@ -224,6 +229,7 @@ KCM.SimpleKCM {
             case "pwr":  cfg_showPower   = val; break;
             case "net":  cfg_showNetwork = val; break;
             case "disk": cfg_showDisk    = val; break;
+            case "fan":  cfg_showFan     = val; break;
         }
         if (!val) {
             if ((key === "cpu" || key === "temp") && cfg_mergeCpuTemp) cfg_mergeCpuTemp = false;
@@ -242,6 +248,7 @@ KCM.SimpleKCM {
             case "pwr":  cfg_compactShowPower   = val; break;
             case "net":  cfg_compactShowNetwork = val; break;
             case "disk": cfg_compactShowDisk    = val; break;
+            case "fan":  cfg_compactShowFan     = val; break;
         }
     }
 

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -20,6 +20,7 @@ PlasmoidItem {
     property bool showPower: Plasmoid.configuration.showPower
     property bool showNetwork: Plasmoid.configuration.showNetwork
     property bool showDisk: Plasmoid.configuration.showDisk
+    property bool showFan: Plasmoid.configuration.showFan
     property bool compactShowCpu: Plasmoid.configuration.compactShowCpu
     property bool compactShowRam: Plasmoid.configuration.compactShowRam
     property bool compactShowTemp: Plasmoid.configuration.compactShowTemp
@@ -28,6 +29,7 @@ PlasmoidItem {
     property bool compactShowPower: Plasmoid.configuration.compactShowPower
     property bool compactShowNetwork: Plasmoid.configuration.compactShowNetwork
     property bool compactShowDisk: Plasmoid.configuration.compactShowDisk
+    property bool compactShowFan: Plasmoid.configuration.compactShowFan
     property string networkInterface: Plasmoid.configuration.networkInterface
     property string batteryDevice: Plasmoid.configuration.batteryDevice
     property string gpuSelection: Plasmoid.configuration.gpuSelection
@@ -49,6 +51,7 @@ PlasmoidItem {
     property string powerIcon: Plasmoid.configuration.powerIcon
     property string networkIcon: Plasmoid.configuration.networkIcon
     property string diskIcon: Plasmoid.configuration.diskIcon
+    property string fanIcon: Plasmoid.configuration.fanIcon
     property string fontFamily: Plasmoid.configuration.fontFamily
     property int fontSize: Plasmoid.configuration.fontSize
     property bool fontBold: Plasmoid.configuration.fontBold
@@ -65,6 +68,7 @@ PlasmoidItem {
     property int updateInterval: Plasmoid.configuration.updateInterval || 2000
     property string tempUnit: Plasmoid.configuration.tempUnit || "C"
     property string networkUnit: Plasmoid.configuration.networkUnit || "bytes"
+    property string fanUnit: Plasmoid.configuration.fanUnit || "rpm"
 
     // --- Color configuration properties ---
 
@@ -176,6 +180,12 @@ PlasmoidItem {
         enabled: root.showDisk
         tempUnit: root.tempUnit
         networkUnit: root.networkUnit
+    }
+
+    FanSensors {
+        id: fans
+        updateInterval: root.updateInterval
+        fanUnit: root.fanUnit
     }
 
     // --- Representations ---
@@ -299,6 +309,12 @@ PlasmoidItem {
                         diskSegs.push({value: disk.diskTempValue, color: root.diskTempColor});
                     items.push({icon: root.diskIcon, label: "DSK:", segments: diskSegs, color: root.baseTextColor});
                 }
+                else if (key === "fan" && root.showFan && root.compactShowFan && fans.hasFanData) {
+                    items.push({
+                        icon: root.fanIcon, label: "FAN:", value: fans.fanValue,
+                        color: root.baseTextColor
+                    });
+                }
             }
             return items;
         }
@@ -383,6 +399,9 @@ PlasmoidItem {
                     if (disk.diskTempValue)
                         items.push({label: "Disk Temp", value: disk.diskTempValue, color: root.diskTempColor});
                 }
+                else if (key === "fan" && root.showFan && fans.hasFanData) {
+                    items.push({label: "Fans", value: fans.fanValue, color: root.baseTextColor});
+                }
             }
             return items;
         }
@@ -424,6 +443,9 @@ PlasmoidItem {
                 var dParts = ["↓" + disk.diskReadValue, "↑" + disk.diskWriteValue];
                 if (disk.diskTempValue) dParts.push(disk.diskTempValue);
                 parts.push("DSK: " + dParts.join(" "));
+            }
+            else if (key === "fan" && root.showFan && fans.hasFanData) {
+                parts.push("FAN: " + fans.fanValue);
             }
         }
         return parts.join("\n");

--- a/contents/ui/sensors/FanSensors.qml
+++ b/contents/ui/sensors/FanSensors.qml
@@ -35,7 +35,7 @@ Item {
             var sensorId = flatSensors.data(idx, Sensors.SensorTreeModel.SensorId);
             if (!sensorId || sensorId.length === 0) continue;
             // Match any sensor that contains /fan and doesn't end with a non-digit (typically fan1, fan2, etc)
-            var match = sensorId.match(/^(lmsensors|cpu|gpu)\/.*\/fan\d+$/i) || sensorId.match(/.*fan.*/i);
+            var match = sensorId.match(/^(lmsensors|cpu|gpu)\/.*\/fan\d+$/i);
             if (!match) continue;
             // Some names are like "cpu_fan", we can try to extract the last part or use the sensor Name
             var name = flatSensors.data(idx, Qt.DisplayRole) || "Fan " + (found.length + 1);
@@ -52,7 +52,6 @@ Item {
         function onRowsInserted() { root.refreshDiscovered(); }
         function onRowsRemoved()  { root.refreshDiscovered(); }
         function onModelReset()   { root.refreshDiscovered(); }
-        function onDataChanged()  { root.refreshDiscovered(); }
     }
 
     Component.onCompleted: refreshDiscovered()
@@ -100,9 +99,13 @@ Item {
 
             var str = "";
             if (fanUnit === "percent") {
-                var max = _modelMax(f.id) || 10000; // Fallback max if not provided
-                var pct = Math.min(100, Math.round((v / max) * 100));
-                str = pct + "%";
+                var max = _modelMax(f.id);
+                if (isNaN(max) || max <= 0) {
+                    str = Math.round(v) + " RPM";
+                } else {
+                    var pct = Math.min(100, Math.round((v / max) * 100));
+                    str = pct + "%";
+                }
             } else {
                 str = Math.round(v) + " RPM";
             }

--- a/contents/ui/sensors/FanSensors.qml
+++ b/contents/ui/sensors/FanSensors.qml
@@ -101,11 +101,10 @@ Item {
             if (fanUnit === "percent") {
                 var max = _modelMax(f.id);
                 if (isNaN(max) || max <= 0) {
-                    str = Math.round(v) + " RPM";
-                } else {
-                    var pct = Math.min(100, Math.round((v / max) * 100));
-                    str = pct + "%";
+                    continue;
                 }
+                var pct = Math.min(100, Math.round((v / max) * 100));
+                str = pct + "%";
             } else {
                 str = Math.round(v) + " RPM";
             }

--- a/contents/ui/sensors/FanSensors.qml
+++ b/contents/ui/sensors/FanSensors.qml
@@ -1,0 +1,115 @@
+import QtQuick
+import org.kde.ksysguard.sensors as Sensors
+import org.kde.kitemmodels as KItemModels
+
+Item {
+    id: root
+
+    property int updateInterval: 2000
+    property string fanUnit: "rpm" // "rpm" or "percent"
+
+    readonly property var discoveredFans: _discovered
+    property var _discovered: []
+
+    readonly property string fanValue: _fanStr
+    readonly property bool hasFanData: _fanStr.length > 0
+    property string _fanStr: ""
+
+    // -------------------------------------------------------------------------
+    // Step 1: Discover available Fans via SensorTreeModel
+    // -------------------------------------------------------------------------
+
+    Sensors.SensorTreeModel {
+        id: sensorTree
+    }
+
+    KItemModels.KDescendantsProxyModel {
+        id: flatSensors
+        model: sensorTree
+    }
+
+    function refreshDiscovered() {
+        var found = [];
+        for (var row = 0; row < flatSensors.rowCount(); row++) {
+            var idx = flatSensors.index(row, 0);
+            var sensorId = flatSensors.data(idx, Sensors.SensorTreeModel.SensorId);
+            if (!sensorId || sensorId.length === 0) continue;
+            // Match any sensor that contains /fan and doesn't end with a non-digit (typically fan1, fan2, etc)
+            var match = sensorId.match(/^(lmsensors|cpu|gpu)\/.*\/fan\d+$/i) || sensorId.match(/.*fan.*/i);
+            if (!match) continue;
+            // Some names are like "cpu_fan", we can try to extract the last part or use the sensor Name
+            var name = flatSensors.data(idx, Qt.DisplayRole) || "Fan " + (found.length + 1);
+            found.push({ id: sensorId, name: name });
+        }
+
+        if (JSON.stringify(found) !== JSON.stringify(_discovered)) {
+            _discovered = found;
+        }
+    }
+
+    Connections {
+        target: flatSensors
+        function onRowsInserted() { root.refreshDiscovered(); }
+        function onRowsRemoved()  { root.refreshDiscovered(); }
+        function onModelReset()   { root.refreshDiscovered(); }
+        function onDataChanged()  { root.refreshDiscovered(); }
+    }
+
+    Component.onCompleted: refreshDiscovered()
+
+    // -------------------------------------------------------------------------
+    // Step 2: Poll discovered fans
+    // -------------------------------------------------------------------------
+
+    readonly property var _activeSensorIds: _discovered.map(function(f){ return f.id; })
+
+    Sensors.SensorDataModel {
+        id: fanData
+        sensors: root._activeSensorIds
+        updateRateLimit: root.updateInterval
+        enabled: root._activeSensorIds.length > 0
+
+        onDataChanged: root.aggregate()
+        onReadyChanged: { if (ready) root.aggregate(); }
+    }
+
+    function _modelValue(sensorId) {
+        var col = fanData.column(sensorId);
+        if (col < 0) return NaN;
+        var idx = fanData.index(0, col);
+        if (!idx.valid) return NaN;
+        var val = fanData.data(idx, Sensors.SensorDataModel.Value);
+        return (val === undefined || val === null) ? NaN : val;
+    }
+
+    function _modelMax(sensorId) {
+        var col = fanData.column(sensorId);
+        if (col < 0) return NaN;
+        var idx = fanData.index(0, col);
+        if (!idx.valid) return NaN;
+        var val = fanData.data(idx, Sensors.SensorDataModel.Maximum);
+        return (val === undefined || val === null) ? NaN : val;
+    }
+
+    function aggregate() {
+        var parts = [];
+        for (var i = 0; i < _discovered.length; i++) {
+            var f = _discovered[i];
+            var v = _modelValue(f.id);
+            if (isNaN(v) || v <= 0) continue; // Ignore 0 RPM or disconnected fans
+
+            var str = "";
+            if (fanUnit === "percent") {
+                var max = _modelMax(f.id) || 10000; // Fallback max if not provided
+                var pct = Math.min(100, Math.round((v / max) * 100));
+                str = pct + "%";
+            } else {
+                str = Math.round(v) + " RPM";
+            }
+            parts.push(str);
+        }
+        _fanStr = parts.join(" ");
+    }
+
+    onFanUnitChanged: aggregate()
+}

--- a/contents/ui/sensors/qmldir
+++ b/contents/ui/sensors/qmldir
@@ -7,3 +7,4 @@ GpuSensors 1.0 GpuSensors.qml
 BatterySensors 1.0 BatterySensors.qml
 NetworkSensors 1.0 NetworkSensors.qml
 DiskSensors 1.0 DiskSensors.qml
+FanSensors 1.0 FanSensors.qml


### PR DESCRIPTION
## Description

This pull request adds support for displaying fan speed metrics in the system monitor, including their configuration and icon selection. The changes introduce new configuration options, UI elements, and a `FanSensors` component to discover and aggregate fan sensor data. Users can now show/hide fan speed, select its unit (RPM or percent), and choose a custom icon.

**Fan Speed Metric Support:**

* Added a new `FanSensors.qml` component to discover available fan sensors, poll their values, and aggregate fan speed data in RPM or percent.
* Updated `main.qml` to integrate fan speed as a configurable metric, including properties, compact and full display logic, and use of the new `FanSensors` component. [[1]](diffhunk://#diff-640bd5a8d5fa5c15db3d9116dcf7765c1bd78ee05d52180a4f3ff450955d876dR23) [[2]](diffhunk://#diff-640bd5a8d5fa5c15db3d9116dcf7765c1bd78ee05d52180a4f3ff450955d876dR185-R190) [[3]](diffhunk://#diff-640bd5a8d5fa5c15db3d9116dcf7765c1bd78ee05d52180a4f3ff450955d876dR312-R317) [[4]](diffhunk://#diff-640bd5a8d5fa5c15db3d9116dcf7765c1bd78ee05d52180a4f3ff450955d876dR402-R404) [[5]](diffhunk://#diff-640bd5a8d5fa5c15db3d9116dcf7765c1bd78ee05d52180a4f3ff450955d876dR447-R449)

**Configuration and UI Enhancements:**

* Extended `main.xml` to include new configuration entries for showing fan metrics, compact display, icon, unit, and default metric order. [[1]](diffhunk://#diff-42a939a77f41b2186c5c8a937cc0a93b195b94a70dc68d7c5d3ec06b19dc85daR34-R36) [[2]](diffhunk://#diff-42a939a77f41b2186c5c8a937cc0a93b195b94a70dc68d7c5d3ec06b19dc85daR61-R63) [[3]](diffhunk://#diff-42a939a77f41b2186c5c8a937cc0a93b195b94a70dc68d7c5d3ec06b19dc85daR127-R129) [[4]](diffhunk://#diff-42a939a77f41b2186c5c8a937cc0a93b195b94a70dc68d7c5d3ec06b19dc85daL131-R140) [[5]](diffhunk://#diff-42a939a77f41b2186c5c8a937cc0a93b195b94a70dc68d7c5d3ec06b19dc85daR208-R210)
* Updated configuration QML files (`configGeneral.qml`, `configIcons.qml`, `configMetrics.qml`) to support fan metric toggles, compact mode, icon selection, and unit selection via the UI. [[1]](diffhunk://#diff-ed0840a06e0e0336c7d175313be42565c391e395f108840410dcb43895494778R19) [[2]](diffhunk://#diff-ed0840a06e0e0336c7d175313be42565c391e395f108840410dcb43895494778R145-R152) [[3]](diffhunk://#diff-e50f25b1d92d87cf85c4e987c28064a70652c9746f2a5b7c942164eb096ad176R19) [[4]](diffhunk://#diff-e50f25b1d92d87cf85c4e987c28064a70652c9746f2a5b7c942164eb096ad176R53-R56) [[5]](diffhunk://#diff-e50f25b1d92d87cf85c4e987c28064a70652c9746f2a5b7c942164eb096ad176R108-R113) [[6]](diffhunk://#diff-e50f25b1d92d87cf85c4e987c28064a70652c9746f2a5b7c942164eb096ad176R127) [[7]](diffhunk://#diff-76cb999476b1b28c00991fd602813bb21ec4e7de6b695410d2b28bd2e3293574R22) [[8]](diffhunk://#diff-76cb999476b1b28c00991fd602813bb21ec4e7de6b695410d2b28bd2e3293574R31) [[9]](diffhunk://#diff-76cb999476b1b28c00991fd602813bb21ec4e7de6b695410d2b28bd2e3293574L169-R171) [[10]](diffhunk://#diff-76cb999476b1b28c00991fd602813bb21ec4e7de6b695410d2b28bd2e3293574L179-R182) [[11]](diffhunk://#diff-76cb999476b1b28c00991fd602813bb21ec4e7de6b695410d2b28bd2e3293574R202) [[12]](diffhunk://#diff-76cb999476b1b28c00991fd602813bb21ec4e7de6b695410d2b28bd2e3293574R217) [[13]](diffhunk://#diff-76cb999476b1b28c00991fd602813bb21ec4e7de6b695410d2b28bd2e3293574R232) [[14]](diffhunk://#diff-76cb999476b1b28c00991fd602813bb21ec4e7de6b695410d2b28bd2e3293574R251)

These changes collectively enable users to monitor fan speeds alongside other hardware metrics, with full customization for display and appearance.


## Related Issue

Fixes #45 

## Testing

- [x] Tested on Plasma 6.6.5
- [x] Distro: Fedora 43
- [x] Widget installs cleanly with `install.sh`
- [x] Widget displays correctly in the panel

## Screenshots

<img width="399" height="33" alt="image" src="https://github.com/user-attachments/assets/58d90391-9829-420b-91ef-eec8c291f2bb" />