### PR TITLE
feat: add System Uptime and Local IP Address metrics

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -34,6 +34,9 @@
         <entry name="showFan" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="showUptime" type="Bool">
+            <default>false</default>
+        </entry>
         <entry name="compactShowCpu" type="Bool">
             <default>true</default>
         </entry>
@@ -61,8 +64,14 @@
         <entry name="compactShowFan" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="compactShowUptime" type="Bool">
+            <default>false</default>
+        </entry>
         <entry name="networkInterface" type="String">
             <default>auto</default>
+        </entry>
+        <entry name="showNetworkIp" type="Bool">
+            <default>false</default>
         </entry>
         <entry name="batteryDevice" type="String">
             <default>auto</default>
@@ -124,6 +133,9 @@
         <entry name="fanIcon" type="String">
             <default>fan</default>
         </entry>
+        <entry name="uptimeIcon" type="String">
+            <default>clock</default>
+        </entry>
         <entry name="fontFamily" type="String">
             <default>monospace</default>
         </entry>
@@ -134,7 +146,7 @@
             <default>false</default>
         </entry>
         <entry name="metricOrder" type="String">
-            <default>cpu,ram,temp,gpu,bat,pwr,net,disk,fan</default>
+            <default>cpu,ram,temp,gpu,bat,pwr,net,disk,fan,uptime</default>
         </entry>
         <entry name="updateInterval" type="Int">
             <default>2000</default>

--- a/contents/ui/configIcons.qml
+++ b/contents/ui/configIcons.qml
@@ -17,6 +17,7 @@ KCM.SimpleKCM {
     property string cfg_networkIcon: "network-wireless"
     property string cfg_diskIcon: "drive-harddisk"
     property string cfg_fanIcon: "fan"
+    property string cfg_uptimeIcon: "clock"
 
     KIconThemes.IconDialog {
         id: cpuIconDialog
@@ -53,6 +54,11 @@ KCM.SimpleKCM {
     KIconThemes.IconDialog {
         id: fanIconDialog
         onIconNameChanged: if (iconName) cfg_fanIcon = iconName
+    }
+
+    KIconThemes.IconDialog {
+        id: uptimeIconDialog
+        onIconNameChanged: if (iconName) cfg_uptimeIcon = iconName
     }
 
     Kirigami.FormLayout {
@@ -111,6 +117,12 @@ KCM.SimpleKCM {
             Button { text: i18n("Change..."); onClicked: fanIconDialog.open(); icon.name: "document-edit" }
         }
 
+        RowLayout {
+            Kirigami.FormData.label: i18n("System Uptime:")
+            Kirigami.Icon { source: cfg_uptimeIcon; isMask: true; Layout.preferredWidth: 22; Layout.preferredHeight: 22 }
+            Button { text: i18n("Change..."); onClicked: uptimeIconDialog.open(); icon.name: "document-edit" }
+        }
+
         Button {
             icon.name: "edit-undo"
             text: i18n("Reset to defaults")
@@ -125,6 +137,7 @@ KCM.SimpleKCM {
                 cfg_networkIcon = "network-wireless";
                 cfg_diskIcon = "drive-harddisk";
                 cfg_fanIcon = "fan";
+                cfg_uptimeIcon = "clock";
             }
         }
     }

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -20,6 +20,7 @@ KCM.SimpleKCM {
     property bool cfg_showNetwork
     property bool cfg_showDisk
     property bool cfg_showFan
+    property bool cfg_showUptime
     property bool cfg_compactShowCpu
     property bool cfg_compactShowRam
     property bool cfg_compactShowTemp
@@ -29,7 +30,9 @@ KCM.SimpleKCM {
     property bool cfg_compactShowNetwork
     property bool cfg_compactShowDisk
     property bool cfg_compactShowFan
+    property bool cfg_compactShowUptime
     property string cfg_networkInterface: "auto"
+    property bool cfg_showNetworkIp: false
     property string cfg_batteryDevice
     property string cfg_gpuSelection: ""
     property string cfg_gpuLabels: ""
@@ -180,7 +183,7 @@ KCM.SimpleKCM {
     }
 
     // --- Metric order helpers ---
-    readonly property var allKeys: ["cpu", "ram", "temp", "gpu", "bat", "pwr", "net", "disk", "fan"]
+    readonly property var allKeys: ["cpu", "ram", "temp", "gpu", "bat", "pwr", "net", "disk", "fan", "uptime"]
 
     readonly property var metricMeta: ({
         "cpu":  { label: i18n("CPU usage"),         icon: "cpu" },
@@ -191,7 +194,8 @@ KCM.SimpleKCM {
         "pwr":  { label: i18n("Power consumption"),  icon: "battery-charging-60" },
         "net":  { label: i18n("Network speed"),      icon: "network-wireless" },
         "disk": { label: i18n("Disk I/O & temp"),    icon: "drive-harddisk" },
-        "fan":  { label: i18n("Fan speed"),          icon: "fan" }
+        "fan":  { label: i18n("Fan speed"),          icon: "fan" },
+        "uptime": { label: i18n("System Uptime"),    icon: "clock" }
     })
 
     property var currentOrder: {
@@ -212,6 +216,7 @@ KCM.SimpleKCM {
             case "net":  return cfg_showNetwork;
             case "disk": return cfg_showDisk;
             case "fan":  return cfg_showFan;
+            case "uptime": return cfg_showUptime;
         }
         return false;
     }
@@ -227,6 +232,7 @@ KCM.SimpleKCM {
             case "net":  return cfg_compactShowNetwork;
             case "disk": return cfg_compactShowDisk;
             case "fan":  return cfg_compactShowFan;
+            case "uptime": return cfg_compactShowUptime;
         }
         return false;
     }
@@ -242,6 +248,7 @@ KCM.SimpleKCM {
             case "net":  cfg_showNetwork = val; break;
             case "disk": cfg_showDisk    = val; break;
             case "fan":  cfg_showFan     = val; break;
+            case "uptime": cfg_showUptime = val; break;
         }
         if (!val) {
             if ((key === "cpu" || key === "temp") && cfg_mergeCpuTemp) cfg_mergeCpuTemp = false;
@@ -261,6 +268,7 @@ KCM.SimpleKCM {
             case "net":  cfg_compactShowNetwork = val; break;
             case "disk": cfg_compactShowDisk    = val; break;
             case "fan":  cfg_compactShowFan     = val; break;
+            case "uptime": cfg_compactShowUptime = val; break;
         }
     }
 
@@ -453,18 +461,28 @@ KCM.SimpleKCM {
                         Layout.leftMargin: Kirigami.Units.gridUnit + Kirigami.Units.smallSpacing
                         Layout.topMargin: Kirigami.Units.smallSpacing
 
-                        sourceComponent: RowLayout {
+                        sourceComponent: ColumnLayout {
                             spacing: Kirigami.Units.smallSpacing
-                            Label { text: i18n("Interface:") }
-                            ComboBox {
-                                id: ifaceCombo
-                                model: metricsPage.ifaceList
-                                currentIndex: {
-                                    var idx = metricsPage.ifaceList.indexOf(cfg_networkInterface);
-                                    return idx >= 0 ? idx : 0;
+
+                            RowLayout {
+                                spacing: Kirigami.Units.smallSpacing
+                                Label { text: i18n("Interface:") }
+                                ComboBox {
+                                    id: ifaceCombo
+                                    model: metricsPage.ifaceList
+                                    currentIndex: {
+                                        var idx = metricsPage.ifaceList.indexOf(cfg_networkInterface);
+                                        return idx >= 0 ? idx : 0;
+                                    }
+                                    onActivated: cfg_networkInterface = metricsPage.ifaceList[currentIndex]
+                                    implicitWidth: Kirigami.Units.gridUnit * 10
                                 }
-                                onActivated: cfg_networkInterface = metricsPage.ifaceList[currentIndex]
-                                implicitWidth: Kirigami.Units.gridUnit * 10
+                            }
+
+                            CheckBox {
+                                text: i18n("Show Local IP Address")
+                                checked: cfg_showNetworkIp
+                                onToggled: cfg_showNetworkIp = checked
                             }
                         }
                     }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -22,6 +22,7 @@ PlasmoidItem {
     property bool showNetwork: Plasmoid.configuration.showNetwork
     property bool showDisk: Plasmoid.configuration.showDisk
     property bool showFan: Plasmoid.configuration.showFan
+    property bool showUptime: Plasmoid.configuration.showUptime
     property bool compactShowCpu: Plasmoid.configuration.compactShowCpu
     property bool compactShowRam: Plasmoid.configuration.compactShowRam
     property bool compactShowTemp: Plasmoid.configuration.compactShowTemp
@@ -31,7 +32,9 @@ PlasmoidItem {
     property bool compactShowNetwork: Plasmoid.configuration.compactShowNetwork
     property bool compactShowDisk: Plasmoid.configuration.compactShowDisk
     property bool compactShowFan: Plasmoid.configuration.compactShowFan
+    property bool compactShowUptime: Plasmoid.configuration.compactShowUptime
     property string networkInterface: Plasmoid.configuration.networkInterface
+    property bool showNetworkIp: Plasmoid.configuration.showNetworkIp
     property string batteryDevice: Plasmoid.configuration.batteryDevice
     property string gpuSelection: Plasmoid.configuration.gpuSelection
     property string gpuLabels: Plasmoid.configuration.gpuLabels
@@ -53,6 +56,7 @@ PlasmoidItem {
     property string networkIcon: Plasmoid.configuration.networkIcon
     property string diskIcon: Plasmoid.configuration.diskIcon
     property string fanIcon: Plasmoid.configuration.fanIcon
+    property string uptimeIcon: Plasmoid.configuration.uptimeIcon
     property string fontFamily: Plasmoid.configuration.fontFamily
     property int fontSize: Plasmoid.configuration.fontSize
     property bool fontBold: Plasmoid.configuration.fontBold
@@ -61,7 +65,7 @@ PlasmoidItem {
     property bool useIcons: displayMode === "icons" || displayMode === "icons+text"
     property bool useText: displayMode === "text" || displayMode === "icons+text"
 
-    property string metricOrder: Plasmoid.configuration.metricOrder || "cpu,ram,temp,gpu,bat,pwr,net,disk"
+    property string metricOrder: Plasmoid.configuration.metricOrder || "cpu,ram,temp,gpu,bat,pwr,net,disk,fan,uptime"
     property var orderedKeys: metricOrder.split(",").map(function (k) {
         return k.trim();
     })
@@ -150,6 +154,7 @@ PlasmoidItem {
     property var network: _sensorsReady ? sensorLoader.item.network : _nullNetwork
     property var disk:    _sensorsReady ? sensorLoader.item.disk    : _nullDisk
     property var fans:    _sensorsReady ? sensorLoader.item.fans    : _nullFans
+    property var uptime:  _sensorsReady ? sensorLoader.item.uptime  : _nullUptime
 
     // Safe defaults so bindings don't error before sensors load
     QtObject {
@@ -206,6 +211,10 @@ PlasmoidItem {
         property string fanValue: ""
         property bool hasFanData: false
     }
+    QtObject {
+        id: _nullUptime
+        property string uptimeValue: ""
+    }
 
     Loader {
         id: sensorLoader
@@ -219,6 +228,7 @@ PlasmoidItem {
             property alias network: _network
             property alias disk:    _disk
             property alias fans:    _fans
+            property alias uptime:  _uptime
 
             CpuSensors {
                 id: _cpu
@@ -270,6 +280,11 @@ PlasmoidItem {
                 id: _fans
                 updateInterval: root.updateInterval
                 fanUnit: root.fanUnit
+            }
+
+            UptimeSensors {
+                id: _uptime
+                updateInterval: root.updateInterval
             }
         }
     }
@@ -401,12 +416,20 @@ PlasmoidItem {
                         icon: root.powerIcon, label: "PWR:", value: battery.powerValue,
                         color: root.baseTextColor
                     });
-                else if (key === "net" && root.showNetwork && root.compactShowNetwork)
+                else if (key === "net" && root.showNetwork && root.compactShowNetwork) {
+                    var netSegs = [
+                        {value: "↓" + network.netDownValue, color: root.baseTextColor},
+                        {value: "↑" + network.netUpValue, color: root.baseTextColor}
+                    ];
+                    if (root.showNetworkIp && network.netIpValue && network.netIpValue !== "..." && network.netIpValue !== "") {
+                        netSegs.push({value: network.netIpValue, color: root.baseTextColor});
+                    }
                     items.push({
                         icon: root.networkIcon, label: "NET:",
-                        value: "↓" + network.netDownValue + " ↑" + network.netUpValue,
+                        segments: netSegs,
                         color: root.baseTextColor
                     });
+                }
                 else if (key === "disk" && root.showDisk && root.compactShowDisk) {
                     var diskSegs = [{value: "↓" + disk.diskReadValue, color: root.baseTextColor},
                                     {value: "↑" + disk.diskWriteValue, color: root.baseTextColor}];
@@ -417,6 +440,12 @@ PlasmoidItem {
                 else if (key === "fan" && root.showFan && root.compactShowFan && fans.hasFanData) {
                     items.push({
                         icon: root.fanIcon, label: "FAN:", value: fans.fanValue,
+                        color: root.baseTextColor
+                    });
+                }
+                else if (key === "uptime" && root.showUptime && root.compactShowUptime && uptime.uptimeValue) {
+                    items.push({
+                        icon: root.uptimeIcon, label: "UPTIME:", value: uptime.uptimeValue,
                         color: root.baseTextColor
                     });
                 }
@@ -497,6 +526,9 @@ PlasmoidItem {
                 else if (key === "net" && root.showNetwork) {
                     items.push({label: "Network ↓", value: network.netDownValue, color: root.baseTextColor});
                     items.push({label: "Network ↑", value: network.netUpValue, color: root.baseTextColor});
+                    if (root.showNetworkIp && network.netIpValue && network.netIpValue !== "..." && network.netIpValue !== "") {
+                        items.push({label: "Local IP", value: network.netIpValue, color: root.baseTextColor});
+                    }
                 }
                 else if (key === "disk" && root.showDisk) {
                     items.push({label: "Disk Read",  value: disk.diskReadValue,  color: root.baseTextColor});
@@ -506,6 +538,9 @@ PlasmoidItem {
                 }
                 else if (key === "fan" && root.showFan && fans.hasFanData) {
                     items.push({label: "Fans", value: fans.fanValue, color: root.baseTextColor});
+                }
+                else if (key === "uptime" && root.showUptime && uptime.uptimeValue) {
+                    items.push({label: "System Uptime", value: uptime.uptimeValue, color: root.baseTextColor});
                 }
             }
             return items;
@@ -542,8 +577,10 @@ PlasmoidItem {
                 parts.push("BAT: " + battery.batValue);
             else if (key === "pwr" && root.showPower && battery.powerValue)
                 parts.push("PWR: " + battery.powerValue);
-            else if (key === "net" && root.showNetwork)
-                parts.push("NET: ↓" + network.netDownValue + " ↑" + network.netUpValue);
+            else if (key === "net" && root.showNetwork) {
+                var ipStr = (root.showNetworkIp && network.netIpValue && network.netIpValue !== "..." && network.netIpValue !== "") ? " " + network.netIpValue : "";
+                parts.push("NET: ↓" + network.netDownValue + " ↑" + network.netUpValue + ipStr);
+            }
             else if (key === "disk" && root.showDisk) {
                 var dParts = ["↓" + disk.diskReadValue, "↑" + disk.diskWriteValue];
                 if (disk.diskTempValue) dParts.push(disk.diskTempValue);
@@ -551,6 +588,9 @@ PlasmoidItem {
             }
             else if (key === "fan" && root.showFan && fans.hasFanData) {
                 parts.push("FAN: " + fans.fanValue);
+            }
+            else if (key === "uptime" && root.showUptime && uptime.uptimeValue) {
+                parts.push("UPTIME: " + uptime.uptimeValue);
             }
         }
         return parts.join("\n");

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -66,9 +66,16 @@ PlasmoidItem {
     property bool useText: displayMode === "text" || displayMode === "icons+text"
 
     property string metricOrder: Plasmoid.configuration.metricOrder || "cpu,ram,temp,gpu,bat,pwr,net,disk,fan,uptime"
-    property var orderedKeys: metricOrder.split(",").map(function (k) {
-        return k.trim();
-    })
+    property var orderedKeys: {
+        var keys = metricOrder.split(",").map(function (k) { return k.trim(); }).filter(function(k) { return k.length > 0; });
+        var allKeys = ["cpu", "ram", "temp", "gpu", "bat", "pwr", "net", "disk", "fan", "uptime"];
+        for (var i = 0; i < allKeys.length; i++) {
+            if (keys.indexOf(allKeys[i]) === -1) {
+                keys.push(allKeys[i]);
+            }
+        }
+        return keys;
+    }
 
     property int updateInterval: Plasmoid.configuration.updateInterval || 2000
     property string tempUnit: Plasmoid.configuration.tempUnit || "C"

--- a/contents/ui/sensors/NetworkSensors.qml
+++ b/contents/ui/sensors/NetworkSensors.qml
@@ -25,6 +25,11 @@ Item {
         return Utils.formatRate(netUpSensor.value, networkUnit);
     }
 
+    readonly property string netIpValue: {
+        if (netIpSensor.status !== Sensors.Sensor.Ready) return "...";
+        return netIpSensor.value;
+    }
+
     Sensors.Sensor {
         id: netDownSensor
         sensorId: "network/" + root.netIfacePath + "/download"
@@ -34,6 +39,12 @@ Item {
     Sensors.Sensor {
         id: netUpSensor
         sensorId: "network/" + root.netIfacePath + "/upload"
+        updateRateLimit: root.updateInterval
+    }
+
+    Sensors.Sensor {
+        id: netIpSensor
+        sensorId: "network/" + root.netIfacePath + "/ipv4address"
         updateRateLimit: root.updateInterval
     }
 

--- a/contents/ui/sensors/NetworkSensors.qml
+++ b/contents/ui/sensors/NetworkSensors.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import org.kde.ksysguard.sensors as Sensors
+import org.kde.kitemmodels as KItemModels
 
 Item {
     id: root
@@ -9,11 +10,89 @@ Item {
     property string networkInterface: "auto"
     property string networkUnit: "bytes"
 
-    readonly property string netIfacePath: {
-        if (networkInterface === "" || networkInterface === "auto")
-            return "all";
-        return networkInterface;
+    // The resolved interface name to use for the IP sensor.
+    // Empty string while still discovering (in auto mode).
+    readonly property string netIpIfacePath: {
+        if (networkInterface !== "" && networkInterface !== "auto")
+            return networkInterface;
+        return _activeIface;
     }
+
+    // The path used for aggregate traffic sensors (download/upload).
+    // "all" is valid for these even in auto mode.
+    readonly property string netIfacePath: {
+        if (networkInterface !== "" && networkInterface !== "auto")
+            return networkInterface;
+        return "all";
+    }
+
+    // Discovered via SensorTreeModel: first non-loopback interface with a
+    // download sensor, used as the IP source when networkInterface is "auto".
+    property string _activeIface: ""
+    property var _discoveredIfaces: []
+
+    // -------------------------------------------------------------------------
+    // Interface discovery via SensorTreeModel (metadata only, no polling)
+    // -------------------------------------------------------------------------
+
+    Sensors.SensorTreeModel { id: sensorTree }
+
+    KItemModels.KDescendantsProxyModel {
+        id: flatSensors
+        model: sensorTree
+    }
+
+    function _refreshInterfaces() {
+        var found = [];
+        for (var row = 0; row < flatSensors.rowCount(); row++) {
+            var idx = flatSensors.index(row, 0);
+            var sid = flatSensors.data(idx, Sensors.SensorTreeModel.SensorId);
+            if (!sid) continue;
+            // Match network/<iface>/download — skip "all" and loopback
+            var match = sid.match(/^network\/([^/]+)\/download$/);
+            if (!match) continue;
+            var iface = match[1];
+            if (iface === "all" || iface === "lo") continue;
+            if (found.indexOf(iface) < 0) found.push(iface);
+        }
+
+        console.debug("[KVitals] NetworkSensors: discovered ifaces = " + JSON.stringify(found));
+        if (JSON.stringify(found) !== JSON.stringify(_discoveredIfaces)) {
+            _discoveredIfaces = found;
+            // Pick the first discovered interface as the default for the IP sensor
+            if (found.length > 0 && _activeIface === "")
+                _activeIface = found[0];
+        }
+    }
+
+    property bool _discoveryDirty: false
+
+    Timer {
+        id: discoveryTimer
+        interval: 500
+        repeat: false
+        running: _discoveryDirty
+        onTriggered: {
+            _discoveryDirty = false;
+            root._refreshInterfaces();
+        }
+    }
+
+    Connections {
+        target: flatSensors
+        function onRowsInserted() { root._discoveryDirty = true; }
+        function onRowsRemoved()  { root._discoveryDirty = true; }
+        function onModelReset()   { root._discoveryDirty = true; }
+    }
+
+    Component.onCompleted: {
+        console.warn("[KVitals] NetworkSensors: ready.");
+        _refreshInterfaces();
+    }
+
+    // -------------------------------------------------------------------------
+    // Traffic sensors (always use netIfacePath / "all" in auto mode)
+    // -------------------------------------------------------------------------
 
     readonly property string netDownValue: {
         if (netDownSensor.status !== Sensors.Sensor.Ready) return "...";
@@ -23,11 +102,6 @@ Item {
     readonly property string netUpValue: {
         if (netUpSensor.status !== Sensors.Sensor.Ready) return "...";
         return Utils.formatRate(netUpSensor.value, networkUnit);
-    }
-
-    readonly property string netIpValue: {
-        if (netIpSensor.status !== Sensors.Sensor.Ready) return "...";
-        return netIpSensor.value;
     }
 
     Sensors.Sensor {
@@ -42,13 +116,22 @@ Item {
         updateRateLimit: root.updateInterval
     }
 
-    Sensors.Sensor {
-        id: netIpSensor
-        sensorId: "network/" + root.netIfacePath + "/ipv4address"
-        updateRateLimit: root.updateInterval
+    // -------------------------------------------------------------------------
+    // IP address sensor — only valid on a specific interface, never "all"
+    // -------------------------------------------------------------------------
+
+    readonly property string netIpValue: {
+        if (netIpIfacePath === "") return "";
+        if (netIpSensor.status !== Sensors.Sensor.Ready) return "...";
+        // Strip CIDR prefix length (e.g. "192.168.1.10/24" → "192.168.1.10")
+        var v = netIpSensor.value || "";
+        var slash = v.indexOf("/");
+        return slash >= 0 ? v.substring(0, slash) : v;
     }
 
-    Component.onCompleted: {
-        console.warn("[KVitals] NetworkSensors: ready.");
+    Sensors.Sensor {
+        id: netIpSensor
+        sensorId: root.netIpIfacePath !== "" ? "network/" + root.netIpIfacePath + "/ipv4withPrefixLength" : ""
+        updateRateLimit: root.updateInterval
     }
 }

--- a/contents/ui/sensors/NetworkSensors.qml
+++ b/contents/ui/sensors/NetworkSensors.qml
@@ -10,30 +10,25 @@ Item {
     property string networkInterface: "auto"
     property string networkUnit: "bytes"
 
-    // The resolved interface name to use for the IP sensor.
-    // Empty string while still discovering (in auto mode).
-    readonly property string netIpIfacePath: {
-        if (networkInterface !== "" && networkInterface !== "auto")
-            return networkInterface;
-        return _activeIface;
-    }
-
-    // The path used for aggregate traffic sensors (download/upload).
-    // "all" is valid for these even in auto mode.
+    // Resolved paths
+    // Traffic sensors aggregate across all interfaces — "all" is valid here.
     readonly property string netIfacePath: {
         if (networkInterface !== "" && networkInterface !== "auto")
             return networkInterface;
         return "all";
     }
 
-    // Discovered via SensorTreeModel: first non-loopback interface with a
-    // download sensor, used as the IP source when networkInterface is "auto".
+    // The IP sensor requires a concrete interface.
+    // In auto mode this is _activeIface, kept fresh by _resolveActiveIface().
+    readonly property string netIpIfacePath: {
+        if (networkInterface !== "" && networkInterface !== "auto")
+            return networkInterface;
+        return _activeIface;
+    }
+
+    // Interface discovery — SensorTreeModel (metadata only, no polling)
     property string _activeIface: ""
     property var _discoveredIfaces: []
-
-    // -------------------------------------------------------------------------
-    // Interface discovery via SensorTreeModel (metadata only, no polling)
-    // -------------------------------------------------------------------------
 
     Sensors.SensorTreeModel { id: sensorTree }
 
@@ -48,21 +43,15 @@ Item {
             var idx = flatSensors.index(row, 0);
             var sid = flatSensors.data(idx, Sensors.SensorTreeModel.SensorId);
             if (!sid) continue;
-            // Match network/<iface>/download — skip "all" and loopback
             var match = sid.match(/^network\/([^/]+)\/download$/);
             if (!match) continue;
             var iface = match[1];
             if (iface === "all" || iface === "lo") continue;
             if (found.indexOf(iface) < 0) found.push(iface);
         }
-
         console.debug("[KVitals] NetworkSensors: discovered ifaces = " + JSON.stringify(found));
-        if (JSON.stringify(found) !== JSON.stringify(_discoveredIfaces)) {
+        if (JSON.stringify(found) !== JSON.stringify(_discoveredIfaces))
             _discoveredIfaces = found;
-            // Pick the first discovered interface as the default for the IP sensor
-            if (found.length > 0 && _activeIface === "")
-                _activeIface = found[0];
-        }
     }
 
     property bool _discoveryDirty: false
@@ -72,10 +61,7 @@ Item {
         interval: 500
         repeat: false
         running: _discoveryDirty
-        onTriggered: {
-            _discoveryDirty = false;
-            root._refreshInterfaces();
-        }
+        onTriggered: { _discoveryDirty = false; root._refreshInterfaces(); }
     }
 
     Connections {
@@ -90,10 +76,56 @@ Item {
         _refreshInterfaces();
     }
 
-    // -------------------------------------------------------------------------
-    // Traffic sensors (always use netIfacePath / "all" in auto mode)
-    // -------------------------------------------------------------------------
+    // Active interface selection — poll all discovered IPs, pick first with value
+    // Sensor IDs for every discovered interface's IP — updated when the
+    // discovered list changes.
+    readonly property var _ipSensorIds: {
+        return _discoveredIfaces.map(function(iface) {
+            return "network/" + iface + "/ipv4withPrefixLength";
+        });
+    }
 
+    // Poll IPs of all discovered interfaces at the same rate as traffic sensors.
+    // Only active in auto mode — when a specific interface is chosen there is
+    // nothing to resolve.
+    Sensors.SensorDataModel {
+        id: ipDiscoveryModel
+        sensors: root._ipSensorIds
+        updateRateLimit: root.updateInterval
+        enabled: root._ipSensorIds.length > 0
+                 && (root.networkInterface === "auto" || root.networkInterface === "")
+
+        onDataChanged: root._resolveActiveIface()
+        onReadyChanged: { if (ready) root._resolveActiveIface(); }
+    }
+
+    // Walk discovered interfaces in order; promote the first one that currently
+    // holds a valid IP address.  Called on every sensor update, so the active
+    // interface is always current — handles Wi-Fi ↔ Ethernet switches and
+    // address loss transparently.
+    function _resolveActiveIface() {
+        for (var i = 0; i < _discoveredIfaces.length; i++) {
+            var iface = _discoveredIfaces[i];
+            var col = ipDiscoveryModel.column("network/" + iface + "/ipv4withPrefixLength");
+            if (col < 0) continue;
+            var val = ipDiscoveryModel.data(ipDiscoveryModel.index(0, col),
+                                            Sensors.SensorDataModel.Value);
+            if (val && typeof val === "string" && val.length > 0) {
+                if (_activeIface !== iface) {
+                    console.warn("[KVitals] NetworkSensors: active IP iface → " + iface + " (" + val + ")");
+                    _activeIface = iface;
+                }
+                return;
+            }
+        }
+        // No interface has an address — clear so the metric hides cleanly.
+        if (_activeIface !== "") {
+            console.warn("[KVitals] NetworkSensors: no active IP iface, clearing.");
+            _activeIface = "";
+        }
+    }
+
+    // Traffic sensors
     readonly property string netDownValue: {
         if (netDownSensor.status !== Sensors.Sensor.Ready) return "...";
         return Utils.formatRate(netDownSensor.value, networkUnit);
@@ -116,14 +148,12 @@ Item {
         updateRateLimit: root.updateInterval
     }
 
-    // -------------------------------------------------------------------------
-    // IP address sensor — only valid on a specific interface, never "all"
-    // -------------------------------------------------------------------------
+    // IP address sensor
 
     readonly property string netIpValue: {
         if (netIpIfacePath === "") return "";
         if (netIpSensor.status !== Sensors.Sensor.Ready) return "...";
-        // Strip CIDR prefix length (e.g. "192.168.1.10/24" → "192.168.1.10")
+        // Strip CIDR suffix: "192.168.1.10/24" → "192.168.1.10"
         var v = netIpSensor.value || "";
         var slash = v.indexOf("/");
         return slash >= 0 ? v.substring(0, slash) : v;
@@ -131,7 +161,9 @@ Item {
 
     Sensors.Sensor {
         id: netIpSensor
-        sensorId: root.netIpIfacePath !== "" ? "network/" + root.netIpIfacePath + "/ipv4withPrefixLength" : ""
+        sensorId: root.netIpIfacePath !== ""
+                  ? "network/" + root.netIpIfacePath + "/ipv4withPrefixLength"
+                  : ""
         updateRateLimit: root.updateInterval
     }
 }

--- a/contents/ui/sensors/UptimeSensors.qml
+++ b/contents/ui/sensors/UptimeSensors.qml
@@ -1,0 +1,37 @@
+import QtQuick
+import org.kde.ksysguard.sensors as Sensors
+
+Item {
+    id: root
+    property bool _dbg: { console.warn("[KVitals] UptimeSensors: constructing..."); return true; }
+
+    property int updateInterval: 2000
+
+    readonly property string uptimeValue: {
+        if (uptimeSensor.status !== Sensors.Sensor.Ready) return "...";
+        return formatUptime(uptimeSensor.value);
+    }
+
+    function formatUptime(seconds) {
+        if (isNaN(seconds)) return "...";
+        var d = Math.floor(seconds / 86400);
+        var h = Math.floor((seconds % 86400) / 3600);
+        var m = Math.floor((seconds % 3600) / 60);
+        
+        var parts = [];
+        if (d > 0) parts.push(d + "d");
+        if (h > 0 || d > 0) parts.push(h + "h");
+        parts.push(m + "m");
+        return parts.join(" ");
+    }
+
+    Sensors.Sensor {
+        id: uptimeSensor
+        sensorId: "os/system/uptime"
+        updateRateLimit: root.updateInterval
+    }
+
+    Component.onCompleted: {
+        console.warn("[KVitals] UptimeSensors: ready.");
+    }
+}

--- a/contents/ui/sensors/qmldir
+++ b/contents/ui/sensors/qmldir
@@ -8,3 +8,4 @@ BatterySensors 1.0 BatterySensors.qml
 NetworkSensors 1.0 NetworkSensors.qml
 DiskSensors 1.0 DiskSensors.qml
 FanSensors 1.0 FanSensors.qml
+UptimeSensors 1.0 UptimeSensors.qml


### PR DESCRIPTION
## Description

- Add UptimeSensors: native ksystemstats sensor (os/system/uptime) with human-readable formatting (Xd Xh Xm)
- Extend NetworkSensors with ipv4address sensor, automatically tied to the selected network interface
- Wire both metrics into compact view, full view, and tooltip
- Add 'Show Local IP Address' toggle under Network settings in configMetrics (stacked correctly in ColumnLayout)
- Register uptimeIcon in configIcons with dialog and reset support
- Add all new config keys to main.xml with safe defaults (off)
- Register UptimeSensors in qmldir

## Testing

- [x] Tested on KDE Plasma 6.6.5
- [x] Distro: Fedora 43
- [x] Widget installs cleanly with `install.sh`
- [x] Widget displays correctly in the panel

## Screenshots

<img width="511" height="39" alt="image" src="https://github.com/user-attachments/assets/e2100a54-2e6f-4722-9de5-f0120c26b784" />