### PR TITLE
feat: add opacity sliders for labels and separators

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -217,5 +217,11 @@
         <entry name="fanUnit" type="String">
             <default>rpm</default>
         </entry>
+        <entry name="labelOpacity" type="Double">
+            <default>0.65</default>
+        </entry>
+        <entry name="separatorOpacity" type="Double">
+            <default>0.4</default>
+        </entry>
     </group>
 </kcfg>

--- a/contents/ui/CompactView.qml
+++ b/contents/ui/CompactView.qml
@@ -151,7 +151,7 @@ RowLayout {
                 width: 1
                 Layout.fillHeight: true
                 color: compactRow.baseTextColor
-                opacity: compactRow.separatorOpacity * 0.5
+                opacity: compactRow.separatorOpacity
             }
 
             ColumnLayout {

--- a/contents/ui/CompactView.qml
+++ b/contents/ui/CompactView.qml
@@ -16,6 +16,8 @@ RowLayout {
     required property int iconSize
     required property color baseTextColor
     required property string layoutType
+    required property real labelOpacity
+    required property real separatorOpacity
 
     readonly property bool isVertical: layoutType === "vertical"
 
@@ -44,7 +46,7 @@ RowLayout {
                     font.family: compactRow.fontFamily
                     font.bold: compactRow.fontBold
                     color: compactRow.baseTextColor
-                    opacity: 0.5
+                    opacity: compactRow.separatorOpacity
                 }
                 PlasmaComponents.Label {
                     text: modelData.value
@@ -93,7 +95,7 @@ RowLayout {
                 font.pixelSize: compactRow.effectiveFontSize
                 font.family: compactRow.fontFamily
                 color: compactRow.baseTextColor
-                opacity: 0.4
+                opacity: compactRow.separatorOpacity
                 Layout.alignment: Qt.AlignVCenter
             }
 
@@ -112,6 +114,7 @@ RowLayout {
                 font.pixelSize: compactRow.effectiveFontSize
                 font.family: compactRow.fontFamily
                 color: compactRow.baseTextColor
+                opacity: compactRow.labelOpacity
                 Layout.alignment: Qt.AlignVCenter
             }
 
@@ -148,7 +151,7 @@ RowLayout {
                 width: 1
                 Layout.fillHeight: true
                 color: compactRow.baseTextColor
-                opacity: 0.2
+                opacity: compactRow.separatorOpacity * 0.5
             }
 
             ColumnLayout {
@@ -201,7 +204,7 @@ RowLayout {
                         font.pixelSize: Math.max(8, compactRow.effectiveFontSize - 2)
                         font.family: compactRow.fontFamily
                         color: compactRow.baseTextColor
-                        opacity: 0.65
+                        opacity: compactRow.labelOpacity
                         Layout.alignment: Qt.AlignVCenter
                     }
                 }

--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -11,6 +11,8 @@ KCM.SimpleKCM {
     property alias cfg_iconSize: iconSizeSlider.value
     property alias cfg_fontSize: fontSizeSlider.value
     property alias cfg_fontBold: fontBoldCheck.checked
+    property alias cfg_labelOpacity: labelOpacitySlider.value
+    property alias cfg_separatorOpacity: separatorOpacitySlider.value
     property string cfg_displayMode: "text"
     property string cfg_fontFamily: "monospace"
     property string cfg_layoutType: "horizontal"
@@ -106,6 +108,34 @@ KCM.SimpleKCM {
             id: fontBoldCheck
             Kirigami.FormData.label: i18n("Bold font:")
             text: i18n("Bold")
+        }
+
+        Slider {
+            id: labelOpacitySlider
+            Kirigami.FormData.label: i18n("Label opacity:")
+            from: 0
+            to: 1
+            stepSize: 0.05
+            value: 0.65
+        }
+
+        Label {
+            text: Math.round(labelOpacitySlider.value * 100) + "%"
+            opacity: 0.7
+        }
+
+        Slider {
+            id: separatorOpacitySlider
+            Kirigami.FormData.label: i18n("Separator opacity:")
+            from: 0
+            to: 1
+            stepSize: 0.05
+            value: 0.4
+        }
+
+        Label {
+            text: Math.round(separatorOpacitySlider.value * 100) + "%"
+            opacity: 0.7
         }
 
         Slider {

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -60,6 +60,8 @@ PlasmoidItem {
     property string fontFamily: Plasmoid.configuration.fontFamily
     property int fontSize: Plasmoid.configuration.fontSize
     property bool fontBold: Plasmoid.configuration.fontBold
+    property real labelOpacity: Plasmoid.configuration.labelOpacity
+    property real separatorOpacity: Plasmoid.configuration.separatorOpacity
     property int effectiveFontSize: fontSize > 0 ? fontSize : Kirigami.Theme.smallFont.pixelSize
 
     property bool useIcons: displayMode === "icons" || displayMode === "icons+text"
@@ -467,6 +469,8 @@ PlasmoidItem {
         fontBold: root.fontBold
         iconSize: root.iconSize
         baseTextColor: root.baseTextColor
+        labelOpacity: root.labelOpacity
+        separatorOpacity: root.separatorOpacity
         onToggleExpanded: root.expanded = !root.expanded
     }
 


### PR DESCRIPTION
## Description

- Added labelOpacity and separatorOpacity to main.xml.
- Exposed opacity sliders in the General configuration tab.
- Passed config values through main.qml to CompactView.
- Replaced hardcoded opacity values with the new settings in both horizontal and vertical layout delegates.
- Applied labelOpacity to horizontal mode labels for consistency.

## Related Issue

Resolves #54 by introducing user-configurable opacity settings for metric labels and separators in the CompactView

## Testing

- [x] Tested on KDE Plasma 6.6.5
- [x] Distro: Fedora Linux 43
- [x] Widget installs cleanly with `install.sh`
- [x] Widget displays correctly in the panel

## Screenshots

<img width="926" height="923" alt="image" src="https://github.com/user-attachments/assets/ed4d963a-d432-4aff-bdee-63eabb6190f8" />
