### PR TITLE
chore(release): bump version to 2.11.0 and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to KVitals will be documented in this file.
 
+## [2.11.0] - 2026-07-13
+
+### Added
+
+- **System Uptime** (`Metrics` settings): New metric displaying how long the system has been running, formatted as `Xd Xh Xm`. Reads from the native `os/system/uptime` ksystemstats sensor — no shell subprocesses (#53).
+- **Local IP Address** (`Metrics` settings — Network): New toggle under the Network metric that shows the IPv4 address of the active network interface next to network speeds (e.g. `NET: ↓ 1.2 MB ↑ 48 KB · 192.168.1.5`). Automatically follows the selected interface, including `auto` mode (#53).
+- **Label Opacity** (`General` settings): Slider to control the transparency of metric labels (`CPU:`, `RAM:`, etc.) in the compact panel view, from 0 (invisible) to 1 (fully opaque). Applies to both horizontal and vertical layout modes (#55).
+- **Separator Opacity** (`General` settings): Slider to control the transparency of the `|` separators between metrics in the compact panel view (#55).
+
 ## [2.10.1] - 2026-06-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ CPU: 26%  |  RAM: 8.8/39.0G  |  TEMP: 96°C  |  🔋BAT: 78%  |  PWR: +20W  |  N
 
 ## Features
 
-- **Live monitoring** — CPU usage, RAM, CPU temperature, GPU metrics (when available), battery status, power draw, network speed, disk I/O, fan speeds
+- **Live monitoring** — CPU usage, RAM, CPU temperature, GPU metrics (when available), battery status, power draw, network speed, disk I/O, fan speeds, system uptime, local IP address
 - **Display modes** — Text, Icons, Icons + Text, or None (values only) for the panel view
 - **Custom icons** — Pick any icon from your installed theme for each metric
 - **Font customization** — Choose any system font and size
+- **Opacity controls** — Independently adjust label and separator transparency in the compact view
 - **Configurable** — Toggle each metric, adjust refresh rate, tune colors, organized in 4 settings tabs
 - **Minimal footprint** — Native KDE KSysGuard sensors + QML, no heavy dependencies or excessive subprocesses
 - **Click to expand** — Detailed popup view with all stats
@@ -77,8 +78,8 @@ plasmashell --replace &
 
 Right-click the widget → **Configure KVitals...** to access settings in four tabs:
 
-- **General** — Display mode, layout, icon size, font, update interval
-- **Metrics** — Toggle CPU, RAM, Temperature, GPU, Battery, Power, Network, Disk, Fan
+- **General** — Display mode, layout, icon size, font, update interval, label/separator opacity
+- **Metrics** — Toggle CPU, RAM, Temperature, GPU, Battery, Power, Network (+ Local IP), Disk, Fan, Uptime
 - **Icons** — Customize icons for each metric from your theme
 - **Colors** — Set custom font colors and optional threshold-based metric colors
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,8 @@ Right-click the widget → **Configure KVitals...** to open the settings dialog.
 | **Font**            | Font family for all panel text (searchable dropdown of system fonts, editable) | monospace          |
 | **Font size**       | Text size in pixels. `0` uses the system default                               | 0 (system default) |
 | **Update interval** | How often stats are refreshed                                                  | 2.0 seconds        |
+| **Label opacity**   | Transparency of metric labels (`CPU:`, `RAM:`, etc.) in the compact view       | 0.6                |
+| **Separator opacity** | Transparency of the `|` dividers between metrics in the compact view         | 0.4                |
 
 ### Display Modes
 
@@ -52,6 +54,8 @@ Right-click the widget → **Configure KVitals...** to open the settings dialog.
 | **Battery Status**    | `BAT:`        | Battery percentage                                  |
 | **Power Consumption** | `PWR:`        | Power draw in watts                                 |
 | **Network Speed**     | `NET:`        | Download/upload speeds                              |
+| **System Uptime**     | `UP:`         | How long the system has been running (`Xd Xh Xm`)  |
+| **Local IP Address**  | (inline)      | IPv4 address of the active interface, shown next to network speeds |
 
 ### Compact Panel Visibility
 
@@ -116,6 +120,7 @@ Each metric has its own icon that can be customized:
 | Battery     | 🔋           | `battery-good`        |
 | Power       | ⚡            | `battery-charging-60` |
 | Network     | 📶           | `network-wireless`    |
+| Uptime      | 🕒           | `clock`               |
 
 Click **"Change..."** to open KDE's native icon picker, which lets you browse and search all icons from your installed
 icon theme (Breeze, Papirus, Tela, etc.).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ Right-click the widget → **Configure KVitals...** to open the settings dialog.
 | **Font**            | Font family for all panel text (searchable dropdown of system fonts, editable) | monospace          |
 | **Font size**       | Text size in pixels. `0` uses the system default                               | 0 (system default) |
 | **Update interval** | How often stats are refreshed                                                  | 2.0 seconds        |
-| **Label opacity**   | Transparency of metric labels (`CPU:`, `RAM:`, etc.) in the compact view       | 0.6                |
+| **Label opacity**   | Transparency of metric labels (`CPU:`, `RAM:`, etc.) in the compact view       | 0.65               |
 | **Separator opacity** | Transparency of the `|` dividers between metrics in the compact view         | 0.4                |
 
 ### Display Modes

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -127,6 +127,26 @@ systemctl --user restart plasma-ksystemstats.service
 !!! warning
     If the directory doesn't exist, the install failed. Re-run `bash install.sh` from the project directory.
 
+## Desktop Not Loading on Reboot (Widget on Desktop)
+
+**Affects:** Versions prior to 2.10.1, when KVitals is placed on the **desktop** (not the panel).
+
+**Symptom:** After a reboot, the KDE Plasma desktop fails to appear or enters a `plasmashell` crash loop. The system is still running but the desktop environment does not display. Logs show a `SIGSEGV` in `KirigamiPlasmaStyle::PlasmaTheme::syncColors()`.
+
+**Root cause:** When `ShellCorona::load()` attaches a widget to the desktop window at boot, it performs a deep recursive `QQuickItemPrivate::refWindow()` walk over the entire QML object tree. On versions before 2.10.1, all seven sensor modules (`CpuSensors`, `MemorySensors`, `TempSensors`, `GpuSensors`, `BatterySensors`, `NetworkSensors`, `FanSensors`) were direct children of `PlasmoidItem`, each owning `SensorTreeModel`, `KDescendantsProxyModel`, and multiple `Sensor` objects. This deep tree was enough to trigger a use-after-free race condition in Kirigami's theme initialization on certain hardware or distro combinations.
+
+**Fix:** Update to KVitals **2.10.1 or later**. Sensor loading is now deferred to the next event loop iteration after window attachment completes, so `refWindow()` always runs on a minimal QML tree. Safe `QtObject` null-stubs cover all sensor property bindings during the brief startup window.
+
+**Workaround (if you cannot update):** Move the widget from the desktop to the panel, or remove it entirely and reinstall after the desktop has fully loaded:
+
+```bash
+# Force-restart plasmashell to recover the desktop
+kquitapp6 plasmashell && kstart plasmashell &
+```
+
+!!! tip
+    If the desktop loads but the widget is missing after using the workaround, right-click the desktop → **Add Widgets** to re-add KVitals.
+
 ## Custom Font Not Applying
 
 **Cause:** The font name might not match exactly.

--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,7 @@
     ],
     "Website": "https://github.com/yassine20011/kvitals",
     "BugReportUrl": "https://github.com/yassine20011/kvitals/issues",
-    "Version": "2.10.1",
+    "Version": "2.11.0",
     "License": "GPL-3.0"
   },
   "KPackageStructure": "Plasma/Applet",


### PR DESCRIPTION
## Description

- Bump version to 2.11.0 in metadata.json
- Add v2.11.0 release notes to CHANGELOG.md
- Update docs to reflect new Uptime and Local IP metrics
- Update docs to reflect new Opacity controls
- Add troubleshooting section for desktop boot crash issue (#41)

