### PR TITLE
feat: customizable label color and CPU/GPU labels

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -7,6 +7,9 @@
         <entry name="showCpu" type="Bool">
             <default>true</default>
         </entry>
+        <entry name="cpuLabel" type="String">
+            <default>CPU</default>
+        </entry>
         <entry name="showCpuFreq" type="Bool">
             <default>false</default>
         </entry>
@@ -153,6 +156,9 @@
         </entry>
         <entry name="useCustomColors" type="Bool">
             <default>false</default>
+        </entry>
+        <entry name="labelColor" type="String">
+            <default></default>
         </entry>
         <entry name="fontColor" type="String">
             <default></default>

--- a/contents/ui/CompactView.qml
+++ b/contents/ui/CompactView.qml
@@ -15,6 +15,7 @@ RowLayout {
     required property bool fontBold
     required property int iconSize
     required property color baseTextColor
+    required property color labelColor
     required property string layoutType
     required property real labelOpacity
     required property real separatorOpacity
@@ -113,7 +114,7 @@ RowLayout {
                 text: itemData.label
                 font.pixelSize: compactRow.effectiveFontSize
                 font.family: compactRow.fontFamily
-                color: compactRow.baseTextColor
+                color: compactRow.labelColor
                 opacity: compactRow.labelOpacity
                 Layout.alignment: Qt.AlignVCenter
             }
@@ -203,7 +204,7 @@ RowLayout {
                         }
                         font.pixelSize: Math.max(8, compactRow.effectiveFontSize - 2)
                         font.family: compactRow.fontFamily
-                        color: compactRow.baseTextColor
+                        color: compactRow.labelColor
                         opacity: compactRow.labelOpacity
                         Layout.alignment: Qt.AlignVCenter
                     }

--- a/contents/ui/FullView.qml
+++ b/contents/ui/FullView.qml
@@ -11,6 +11,7 @@ ColumnLayout {
 
     required property var metricsModel
     required property color baseTextColor
+    required property color labelColor
     required property bool fontBold
 
     PlasmaComponents.Label {
@@ -33,7 +34,7 @@ ColumnLayout {
 
             PlasmaComponents.Label {
                 text: modelData.label
-                color: fullView.baseTextColor
+                color: fullView.labelColor
                 opacity: 0.7
                 Layout.fillWidth: true
             }

--- a/contents/ui/configColors.qml
+++ b/contents/ui/configColors.qml
@@ -11,6 +11,7 @@ KCM.SimpleKCM {
 
     property alias cfg_useCustomColors: useCustomColorsCheck.checked
     property string cfg_fontColor
+    property string cfg_labelColor
     property alias cfg_enableThresholdColors: enableThresholdCheck.checked
     property string cfg_warningColor: "#e5a50a"
     property string cfg_criticalColor: "#da4453"
@@ -134,6 +135,71 @@ KCM.SimpleKCM {
                 text: i18n("Reset")
                 icon.name: "edit-undo"
                 onClicked: { fontColorField.text = ""; cfg_fontColor = "" }
+            }
+        }
+
+        // === Section: Label Color ===
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: i18n("Label Color")
+        }
+
+        RowLayout {
+            Kirigami.FormData.label: i18n("Color:")
+            spacing: Kirigami.Units.smallSpacing
+
+            Button {
+                id: labelColorButton
+                text: ""
+                padding: 0
+                implicitWidth: Kirigami.Units.gridUnit * 2
+                implicitHeight: Kirigami.Units.gridUnit * 1.5
+                onClicked: colorsPage.openColorDialog(labelColorDialog, cfg_labelColor, Kirigami.Theme.textColor)
+
+                background: Rectangle {
+                    radius: 4
+                    border.width: 1
+                    border.color: labelColorButton.visualFocus ? Kirigami.Theme.highlightColor : Qt.rgba(1, 1, 1, 0.15)
+                    color: "transparent"
+
+                    Rectangle {
+                        anchors.fill: parent
+                        anchors.margins: 2
+                        radius: 3
+                        color: colorsPage.isRgbHex(cfg_labelColor) ? cfg_labelColor : Kirigami.Theme.textColor
+                    }
+                }
+            }
+
+            Platform.ColorDialog {
+                id: labelColorDialog
+                title: i18n("Choose Label Color")
+                parentWindow: colorsPage.Window.window
+                onAccepted: {
+                    const hex = colorsPage.colorToRgbHex(color)
+                    if (!hex) { return }
+                    if (hex !== labelColorField.text) { labelColorField.text = hex }
+                    cfg_labelColor = hex
+                }
+            }
+
+            TextField {
+                id: labelColorField
+                placeholderText: i18n("Empty = base text color")
+                text: cfg_labelColor
+                maximumLength: 7
+                Layout.preferredWidth: 100
+                onTextChanged: {
+                    if (/^#[0-9A-Fa-f]{6}$/.test(text))
+                        cfg_labelColor = text
+                }
+            }
+
+            Button {
+                text: i18n("Reset")
+                icon.name: "edit-undo"
+                onClicked: { labelColorField.text = ""; cfg_labelColor = "" }
             }
         }
 
@@ -407,6 +473,8 @@ KCM.SimpleKCM {
                 useCustomColorsCheck.checked = false
                 fontColorField.text = ""
                 cfg_fontColor = ""
+                labelColorField.text = ""
+                cfg_labelColor = ""
                 enableThresholdCheck.checked = false
                 warningColorField.text = colorsPage.defaultWarningColor
                 cfg_warningColor = colorsPage.defaultWarningColor

--- a/contents/ui/configColors.qml
+++ b/contents/ui/configColors.qml
@@ -147,6 +147,7 @@ KCM.SimpleKCM {
 
         RowLayout {
             Kirigami.FormData.label: i18n("Color:")
+            enabled: cfg_useCustomColors
             spacing: Kirigami.Units.smallSpacing
 
             Button {

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -31,6 +31,7 @@ KCM.SimpleKCM {
     property bool cfg_compactShowDisk
     property bool cfg_compactShowFan
     property bool cfg_compactShowUptime
+    property string cfg_cpuLabel: "CPU"
     property string cfg_networkInterface: "auto"
     property bool cfg_showNetworkIp: false
     property string cfg_batteryDevice
@@ -425,6 +426,17 @@ KCM.SimpleKCM {
 
                         sourceComponent: ColumnLayout {
                             spacing: Kirigami.Units.smallSpacing
+
+                            RowLayout {
+                                spacing: Kirigami.Units.smallSpacing
+                                Label { text: i18n("Label:"); opacity: 0.8 }
+                                TextField {
+                                    implicitWidth: Kirigami.Units.gridUnit * 12
+                                    text: cfg_cpuLabel
+                                    placeholderText: i18n("CPU")
+                                    onTextEdited: cfg_cpuLabel = text.trim() || "CPU"
+                                }
+                            }
 
                             RowLayout {
                                 spacing: Kirigami.Units.largeSpacing

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -90,7 +90,7 @@ PlasmoidItem {
     property bool useCustomColors: Plasmoid.configuration.useCustomColors
     property string fontColor: Plasmoid.configuration.fontColor
     property string labelColor: Plasmoid.configuration.labelColor || ""
-    property color resolvedLabelColor: labelColor ? labelColor : baseTextColor
+    property color resolvedLabelColor: (useCustomColors && labelColor) ? labelColor : baseTextColor
     property bool enableThresholdColors: Plasmoid.configuration.enableThresholdColors
     property string warningColor: Plasmoid.configuration.warningColor || "#e5a50a"
     property string criticalColor: Plasmoid.configuration.criticalColor || "#da4453"
@@ -376,37 +376,38 @@ PlasmoidItem {
                                     items.push({icon: root.gpuIcon, label: label, segments: segs2, color: root.gpuColor});
                             }
                         }
-                    } else if (root.splitGpu) {
-                        var _gpuLabel0 = gpu.gpuDataList.length > 0 ? gpu.gpuDataList[0].name + ":" : "GPU:";
-                        if (gpu.hasGpuUsageData)
-                            items.push({icon: root.gpuIcon, label: _gpuLabel0, value: gpu.gpuValue, color: root.gpuColor});
-                        if (gpu.hasGpuVramData)
-                            items.push({
-                                icon: root.gpuIcon,
-                                label: "VRAM:",
-                                value: gpu.gpuRamValue,
-                                color: root.baseTextColor
-                            });
-                        if (gpu.hasGpuTempData)
-                            items.push({
-                                icon: root.gpuIcon,
-                                label: "GTEMP:",
-                                value: gpu.gpuTempValue,
-                                color: root.gpuTempColor
-                            });
                     } else {
                         var _gpuLabel0 = gpu.gpuDataList.length > 0 ? gpu.gpuDataList[0].name + ":" : "GPU:";
-                        var gpuSegs = [];
-                        if (gpu.hasGpuUsageData)
-                            gpuSegs.push({value: gpu.gpuValue, color: root.gpuColor});
-                        if (gpu.hasGpuVramData)
-                            gpuSegs.push({value: gpu.gpuRamValue, color: root.baseTextColor});
-                        if (gpu.hasGpuTempData)
-                            gpuSegs.push({value: gpu.gpuTempValue, color: root.gpuTempColor});
-                        items.push({
-                            icon: root.gpuIcon, label: _gpuLabel0, segments: gpuSegs,
-                            color: root.gpuColor
-                        });
+                        if (root.splitGpu) {
+                            if (gpu.hasGpuUsageData)
+                                items.push({icon: root.gpuIcon, label: _gpuLabel0, value: gpu.gpuValue, color: root.gpuColor});
+                            if (gpu.hasGpuVramData)
+                                items.push({
+                                    icon: root.gpuIcon,
+                                    label: "VRAM:",
+                                    value: gpu.gpuRamValue,
+                                    color: root.baseTextColor
+                                });
+                            if (gpu.hasGpuTempData)
+                                items.push({
+                                    icon: root.gpuIcon,
+                                    label: "GTEMP:",
+                                    value: gpu.gpuTempValue,
+                                    color: root.gpuTempColor
+                                });
+                        } else {
+                            var gpuSegs = [];
+                            if (gpu.hasGpuUsageData)
+                                gpuSegs.push({value: gpu.gpuValue, color: root.gpuColor});
+                            if (gpu.hasGpuVramData)
+                                gpuSegs.push({value: gpu.gpuRamValue, color: root.baseTextColor});
+                            if (gpu.hasGpuTempData)
+                                gpuSegs.push({value: gpu.gpuTempValue, color: root.gpuTempColor});
+                            items.push({
+                                icon: root.gpuIcon, label: _gpuLabel0, segments: gpuSegs,
+                                color: root.gpuColor
+                            });
+                        }
                     }
                 } else if (key === "bat" && root.showBattery && root.compactShowBattery && battery.batValue) {
                     if (root.mergeBatPwr && root.showPower && root.compactShowPower && battery.powerValue) {

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -42,6 +42,7 @@ PlasmoidItem {
     property string layoutType: Plasmoid.configuration.layoutType
     property bool mergeCpuTemp: Plasmoid.configuration.mergeCpuTemp
     property bool mergeCpuFreq: Plasmoid.configuration.mergeCpuFreq
+    property string cpuLabel: Plasmoid.configuration.cpuLabel || "CPU"
     property bool showCpuFreq: Plasmoid.configuration.showCpuFreq
     property bool mergeBatPwr: Plasmoid.configuration.mergeBatPwr
     property bool splitGpu: Plasmoid.configuration.splitGpu
@@ -88,6 +89,8 @@ PlasmoidItem {
 
     property bool useCustomColors: Plasmoid.configuration.useCustomColors
     property string fontColor: Plasmoid.configuration.fontColor
+    property string labelColor: Plasmoid.configuration.labelColor || ""
+    property color resolvedLabelColor: labelColor ? labelColor : baseTextColor
     property bool enableThresholdColors: Plasmoid.configuration.enableThresholdColors
     property string warningColor: Plasmoid.configuration.warningColor || "#e5a50a"
     property string criticalColor: Plasmoid.configuration.criticalColor || "#da4453"
@@ -330,17 +333,17 @@ PlasmoidItem {
                                     {value: temp.tempValue, color: root.tempColor}];
                         if (root.mergeCpuFreq && root.showCpuFreq)
                             segs.push({value: cpu.cpuFreqValue, color: root.baseTextColor});
-                        items.push({icon: root.cpuIcon, label: "CPU:", color: root.cpuColor, segments: segs});
+                        items.push({icon: root.cpuIcon, label: root.cpuLabel + ":", color: root.cpuColor, segments: segs});
                     } else if (root.mergeCpuFreq && root.showCpuFreq) {
                         items.push({
-                            icon: root.cpuIcon, label: "CPU:", color: root.cpuColor,
+                            icon: root.cpuIcon, label: root.cpuLabel + ":", color: root.cpuColor,
                             segments: [
                                 {value: cpu.cpuValue, color: root.cpuColor},
                                 {value: cpu.cpuFreqValue, color: root.baseTextColor}
                             ]
                         });
                     } else {
-                        items.push({icon: root.cpuIcon, label: "CPU:", value: cpu.cpuValue, color: root.cpuColor});
+                        items.push({icon: root.cpuIcon, label: root.cpuLabel + ":", value: cpu.cpuValue, color: root.cpuColor});
                     }
                 } else if (key === "ram" && root.showRam && root.compactShowRam && memory.ramValue)
                     items.push({
@@ -374,8 +377,9 @@ PlasmoidItem {
                             }
                         }
                     } else if (root.splitGpu) {
+                        var _gpuLabel0 = gpu.gpuDataList.length > 0 ? gpu.gpuDataList[0].name + ":" : "GPU:";
                         if (gpu.hasGpuUsageData)
-                            items.push({icon: root.gpuIcon, label: "GPU:", value: gpu.gpuValue, color: root.gpuColor});
+                            items.push({icon: root.gpuIcon, label: _gpuLabel0, value: gpu.gpuValue, color: root.gpuColor});
                         if (gpu.hasGpuVramData)
                             items.push({
                                 icon: root.gpuIcon,
@@ -391,6 +395,7 @@ PlasmoidItem {
                                 color: root.gpuTempColor
                             });
                     } else {
+                        var _gpuLabel0 = gpu.gpuDataList.length > 0 ? gpu.gpuDataList[0].name + ":" : "GPU:";
                         var gpuSegs = [];
                         if (gpu.hasGpuUsageData)
                             gpuSegs.push({value: gpu.gpuValue, color: root.gpuColor});
@@ -399,7 +404,7 @@ PlasmoidItem {
                         if (gpu.hasGpuTempData)
                             gpuSegs.push({value: gpu.gpuTempValue, color: root.gpuTempColor});
                         items.push({
-                            icon: root.gpuIcon, label: "GPU:", segments: gpuSegs,
+                            icon: root.gpuIcon, label: _gpuLabel0, segments: gpuSegs,
                             color: root.gpuColor
                         });
                     }
@@ -469,6 +474,7 @@ PlasmoidItem {
         fontBold: root.fontBold
         iconSize: root.iconSize
         baseTextColor: root.baseTextColor
+        labelColor: root.resolvedLabelColor
         labelOpacity: root.labelOpacity
         separatorOpacity: root.separatorOpacity
         onToggleExpanded: root.expanded = !root.expanded
@@ -476,6 +482,7 @@ PlasmoidItem {
 
     fullRepresentation: FullView {
         baseTextColor: root.baseTextColor
+        labelColor: root.resolvedLabelColor
         fontBold: root.fontBold
         metricsModel: {
             var items = [];
@@ -483,12 +490,12 @@ PlasmoidItem {
                 var key = root.orderedKeys[i];
                 if (key === "cpu" && root.showCpu)
                     items.push({
-                        label: "CPU Usage", value: cpu.cpuValue,
+                        label: root.cpuLabel + " Usage", value: cpu.cpuValue,
                         color: root.cpuColor
                     });
                 if (key === "cpu" && root.showCpu && root.showCpuFreq)
                     items.push({
-                        label: "CPU Frequency", value: cpu.cpuFreqValue,
+                        label: root.cpuLabel + " Frequency", value: cpu.cpuFreqValue,
                         color: root.baseTextColor
                     });
                 else if (key === "ram" && root.showRam)
@@ -498,7 +505,7 @@ PlasmoidItem {
                     });
                 else if (key === "temp" && root.showTemp && temp.tempValue !== "--")
                     items.push({
-                        label: "CPU Temp", value: temp.tempValue,
+                        label: root.cpuLabel + " Temp", value: temp.tempValue,
                         color: root.tempColor
                     });
                 else if (key === "gpu" && root.showGpu) {
@@ -511,16 +518,17 @@ PlasmoidItem {
                             if (gd.temp)  items.push({label: label + " Temp",  value: gd.temp,  color: root.gpuTempColor});
                         }
                     } else {
+                        var _gpuName = gpu.gpuDataList.length > 0 ? gpu.gpuDataList[0].name : "GPU";
                         if (gpu.hasGpuUsageData) items.push({
-                            label: "GPU Usage", value: gpu.gpuValue,
+                            label: _gpuName + " Usage", value: gpu.gpuValue,
                             color: root.gpuColor
                         });
                         if (gpu.hasGpuVramData) items.push({
-                            label: "GPU VRAM", value: gpu.gpuRamValue,
+                            label: _gpuName + " VRAM", value: gpu.gpuRamValue,
                             color: root.baseTextColor
                         });
                         if (gpu.hasGpuTempData) items.push({
-                            label: "GPU Temp", value: gpu.gpuTempValue,
+                            label: _gpuName + " Temp", value: gpu.gpuTempValue,
                             color: root.gpuTempColor
                         });
                     }
@@ -566,7 +574,7 @@ PlasmoidItem {
         for (var i = 0; i < root.orderedKeys.length; i++) {
             var key = root.orderedKeys[i];
             if (key === "cpu" && root.showCpu && cpu.cpuValue)
-                parts.push("CPU: " + cpu.cpuValue);
+                parts.push(root.cpuLabel + ": " + cpu.cpuValue);
             else if (key === "ram" && root.showRam && memory.ramValue)
                 parts.push("RAM: " + memory.ramValue);
             else if (key === "temp" && root.showTemp && temp.tempValue && temp.tempValue !== "--")
@@ -580,9 +588,10 @@ PlasmoidItem {
                         if (vals.length > 0) parts.push(label + ": " + vals.join(" "));
                     }
                 } else {
-                    if (gpu.hasGpuUsageData) parts.push("GPU: " + gpu.gpuValue);
+                    var _gpuName = gpu.gpuDataList.length > 0 ? gpu.gpuDataList[0].name : "GPU";
+                    if (gpu.hasGpuUsageData) parts.push(_gpuName + ": " + gpu.gpuValue);
                     if (gpu.hasGpuVramData) parts.push("VRAM: " + gpu.gpuRamValue);
-                    if (gpu.hasGpuTempData) parts.push("GPU TEMP: " + gpu.gpuTempValue);
+                    if (gpu.hasGpuTempData) parts.push(_gpuName + " TEMP: " + gpu.gpuTempValue);
                 }
             } else if (key === "bat" && root.showBattery && battery.batValue)
                 parts.push("BAT: " + battery.batValue);


### PR DESCRIPTION
- Add **labelColor** config (optional hex) to set a separate color for metric labels in both compact and full views, with color picker in Colors config page\n- Add **cpuLabel** config (default 'CPU') to rename CPU label to custom name (e.g. hardware model), with text field in Metrics config page\n- Change GPU label behaviour: single-GPU path now uses the custom name from gpuLabels or the discovered name (e.g. 'GPU 1') instead of the previous hardcoded 'GPU'