### PR TITLE
fix: remove programmatic config write to prevent SIGSEGV during boot (re-fix #42)

### DIFF
--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -95,14 +95,7 @@ KCM.SimpleKCM {
         function onDataChanged()  { metricsPage._discoveryDirty = true; }
     }
 
-    readonly property var discoveredGpus: {
-        if (_liveDiscoveredGpus.length > 0) return _liveDiscoveredGpus;
-        if (!cfg_gpuDiscovered) return [];
-        return cfg_gpuDiscovered.split(",").filter(function(s){ return s.indexOf(":") >= 0; }).map(function(s){
-            var parts = s.split(":");
-            return { id: parts[0], name: parts.slice(1).join(":") };
-        });
-    }
+    readonly property var discoveredGpus: _liveDiscoveredGpus
 
     // --- Network interface discovery ---
     property var ifaceList: ["auto"]

--- a/contents/ui/sensors/GpuSensors.qml
+++ b/contents/ui/sensors/GpuSensors.qml
@@ -114,9 +114,6 @@ Item {
         if (JSON.stringify(found) !== JSON.stringify(_discovered)) {
             console.warn("[KVitals] GpuSensors: discovered GPUs updated = " + JSON.stringify(found));
             _discovered = found;
-            if (typeof Plasmoid !== "undefined" && Plasmoid.configuration)
-                Plasmoid.configuration.gpuDiscovered =
-                    found.map(function(g){ return g.id + ":" + g.name; }).join(",");
         }
     }
 


### PR DESCRIPTION
## Description

**GPU discovery and configuration handling:**

* The `discoveredGpus` property in `configMetrics.qml` now directly references `_liveDiscoveredGpus`, eliminating the previous logic that parsed and reconstructed GPU data from a serialized string in `cfg_gpuDiscovered`.
* In `GpuSensors.qml`, the code that updated `Plasmoid.configuration.gpuDiscovered` with a serialized string of discovered GPUs has been removed, further decoupling the configuration from manual string management.

## Related Issue

Fixes #41 

## Testing

- [x] Tested on KDE Plasma 6.7.2
- [x] Distro: Fedora 43
- [x] Widget installs cleanly with `install.sh`
- [x] Widget displays correctly in the panel

