### PR TITLE
Fix: General tab freeze and replace ComboBox with TextField+Popup for font search

### DIFF
--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -139,8 +139,8 @@ KCM.SimpleKCM {
                 }
 
                 onEditingFinished: {
-                    cfg_fontFamily = text;
                     if (!fontSuggestionsList.activeFocus) {
+                        cfg_fontFamily = text;
                         fontPopup.close();
                     }
                 }

--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -71,24 +71,111 @@ KCM.SimpleKCM {
             visible: configPage.iconsEnabled
         }
 
-        ComboBox {
-            id: fontFamilyCombo
+        RowLayout {
+            id: fontRow
             Kirigami.FormData.label: i18n("Font:")
-            model: Qt.fontFamilies()
-            editable: true
-            currentIndex: {
-                var families = Qt.fontFamilies();
-                var idx = families.indexOf(cfg_fontFamily);
-                return idx >= 0 ? idx : 0;
+
+            property var allFonts: []
+            property var defaultFonts: [
+                "monospace", "Sans Serif", "Hack", "Fira Code",
+                "JetBrains Mono", "Noto Sans", "Roboto", "Inter",
+                "DejaVu Sans Mono", "Liberation Mono"
+            ]
+
+            function filterFonts(query) {
+                if (allFonts.length === 0) {
+                    allFonts = Qt.fontFamilies();
+                }
+                var q = query.trim().toLowerCase();
+                if (q === "") return defaultFonts.slice();
+                var results = [];
+                for (var i = 0; i < allFonts.length && results.length < 50; i++) {
+                    if (allFonts[i].toLowerCase().indexOf(q) !== -1) {
+                        results.push(allFonts[i]);
+                    }
+                }
+                return results;
             }
-            onActivated: {
-                cfg_fontFamily = currentText;
+
+            TextField {
+                id: fontInput
+                Layout.preferredWidth: 200
+                text: cfg_fontFamily
+                placeholderText: i18n("Type to search fonts...")
+
+                onTextEdited: {
+                    fontSuggestionsModel.clear();
+                    var filtered = fontRow.filterFonts(text);
+                    for (var i = 0; i < filtered.length; i++) {
+                        fontSuggestionsModel.append({ name: filtered[i] });
+                    }
+                    fontPopup.open();
+                }
+
+                onEditingFinished: {
+                    cfg_fontFamily = text;
+                    fontPopup.close();
+                }
+
+                Keys.onEscapePressed: fontPopup.close()
+                Keys.onDownPressed: {
+                    fontPopup.open();
+                    fontSuggestionsList.forceActiveFocus();
+                    fontSuggestionsList.currentIndex = 0;
+                }
             }
-            onAccepted: {
-                cfg_fontFamily = editText;
+
+            Popup {
+                id: fontPopup
+                x: fontInput.x
+                y: fontInput.y + fontInput.height
+                width: fontInput.width
+                height: Math.min(fontSuggestionsList.contentHeight, 250)
+                padding: 0
+                closePolicy: Popup.CloseOnPressOutside
+
+                ListView {
+                    id: fontSuggestionsList
+                    anchors.fill: parent
+                    clip: true
+                    model: ListModel { id: fontSuggestionsModel }
+
+                    delegate: ItemDelegate {
+                        width: fontSuggestionsList.width
+                        text: model.name
+                        highlighted: fontSuggestionsList.currentIndex === index
+                        onClicked: {
+                            cfg_fontFamily = model.name;
+                            fontInput.text = model.name;
+                            fontPopup.close();
+                        }
+                    }
+
+                    Keys.onReturnPressed: {
+                        if (currentIndex >= 0) {
+                            var item = fontSuggestionsModel.get(currentIndex);
+                            cfg_fontFamily = item.name;
+                            fontInput.text = item.name;
+                        }
+                        fontPopup.close();
+                        fontInput.forceActiveFocus();
+                    }
+
+                    Keys.onEscapePressed: {
+                        fontPopup.close();
+                        fontInput.forceActiveFocus();
+                    }
+                }
             }
-            popup.height: 300
+
+            Component.onCompleted: {
+                var defaults = fontRow.defaultFonts;
+                for (var i = 0; i < defaults.length; i++) {
+                    fontSuggestionsModel.append({ name: defaults[i] });
+                }
+            }
         }
+
 
         Slider {
             id: fontSizeSlider

--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -176,6 +176,11 @@ KCM.SimpleKCM {
             }
         }
 
+        Label {
+            text: i18n("Type to search, ↓ to browse, Enter or click to select")
+            opacity: 0.6
+            font.pointSize: fontSizeSlider.value > 0 ? fontSizeSlider.value * 0.8 : -1
+        }
 
         Slider {
             id: fontSizeSlider

--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -76,18 +76,40 @@ KCM.SimpleKCM {
             Kirigami.FormData.label: i18n("Font:")
 
             property var allFonts: []
-            property var defaultFonts: [
+            property var installedDefaults: []
+
+            readonly property var candidateFonts: [
                 "monospace", "Sans Serif", "Hack", "Fira Code",
                 "JetBrains Mono", "Noto Sans", "Roboto", "Inter",
                 "DejaVu Sans Mono", "Liberation Mono"
             ]
 
-            function filterFonts(query) {
+            function ensureFontsLoaded() {
                 if (allFonts.length === 0) {
                     allFonts = Qt.fontFamilies();
+                    var installed = [];
+                    for (var i = 0; i < candidateFonts.length; i++) {
+                        if (allFonts.indexOf(candidateFonts[i]) !== -1) {
+                            installed.push(candidateFonts[i]);
+                        }
+                    }
+                    installedDefaults = installed;
                 }
+            }
+
+            function buildInitialList() {
+                ensureFontsLoaded();
+                var list = installedDefaults.slice();
+                if (cfg_fontFamily && list.indexOf(cfg_fontFamily) === -1) {
+                    list.unshift(cfg_fontFamily);
+                }
+                return list;
+            }
+
+            function filterFonts(query) {
+                ensureFontsLoaded();
                 var q = query.trim().toLowerCase();
-                if (q === "") return defaultFonts.slice();
+                if (q === "") return buildInitialList();
                 var results = [];
                 for (var i = 0; i < allFonts.length && results.length < 50; i++) {
                     if (allFonts[i].toLowerCase().indexOf(q) !== -1) {
@@ -97,38 +119,55 @@ KCM.SimpleKCM {
                 return results;
             }
 
+            function populateList(query) {
+                fontSuggestionsModel.clear();
+                var filtered = filterFonts(query);
+                for (var i = 0; i < filtered.length; i++) {
+                    fontSuggestionsModel.append({ name: filtered[i] });
+                }
+            }
+
             TextField {
                 id: fontInput
                 Layout.preferredWidth: 200
                 text: cfg_fontFamily
                 placeholderText: i18n("Type to search fonts...")
 
-                onTextEdited: {
-                    fontSuggestionsModel.clear();
-                    var filtered = fontRow.filterFonts(text);
-                    for (var i = 0; i < filtered.length; i++) {
-                        fontSuggestionsModel.append({ name: filtered[i] });
+                onActiveFocusChanged: {
+                    if (activeFocus) {
+                        fontRow.populateList("");
+                        fontPopup.open();
                     }
+                }
+
+                onTextEdited: {
+                    fontRow.populateList(text);
                     fontPopup.open();
                 }
 
                 onEditingFinished: {
                     cfg_fontFamily = text;
-                    fontPopup.close();
+                    if (!fontSuggestionsList.activeFocus) {
+                        fontPopup.close();
+                    }
                 }
 
-                Keys.onEscapePressed: fontPopup.close()
+                Keys.onEscapePressed: {
+                    fontPopup.close();
+                }
                 Keys.onDownPressed: {
+                    fontRow.populateList(text);
                     fontPopup.open();
+                    fontSuggestionsList.currentIndex = -1;
                     fontSuggestionsList.forceActiveFocus();
-                    fontSuggestionsList.currentIndex = 0;
                 }
             }
 
             Popup {
                 id: fontPopup
-                x: fontInput.x
-                y: fontInput.y + fontInput.height
+                parent: fontInput
+                x: 0
+                y: fontInput.height
                 width: fontInput.width
                 height: Math.min(fontSuggestionsList.contentHeight, 250)
                 padding: 0
@@ -148,6 +187,7 @@ KCM.SimpleKCM {
                             cfg_fontFamily = model.name;
                             fontInput.text = model.name;
                             fontPopup.close();
+                            fontInput.forceActiveFocus();
                         }
                     }
 
@@ -167,14 +207,8 @@ KCM.SimpleKCM {
                     }
                 }
             }
-
-            Component.onCompleted: {
-                var defaults = fontRow.defaultFonts;
-                for (var i = 0; i < defaults.length; i++) {
-                    fontSuggestionsModel.append({ name: defaults[i] });
-                }
-            }
         }
+
 
         Label {
             text: i18n("Type to search, ↓ to browse, Enter or click to select")

--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -133,13 +133,6 @@ KCM.SimpleKCM {
                 text: cfg_fontFamily
                 placeholderText: i18n("Type to search fonts...")
 
-                onActiveFocusChanged: {
-                    if (activeFocus) {
-                        fontRow.populateList("");
-                        fontPopup.open();
-                    }
-                }
-
                 onTextEdited: {
                     fontRow.populateList(text);
                     fontPopup.open();
@@ -208,6 +201,7 @@ KCM.SimpleKCM {
                 }
             }
         }
+
 
 
         Label {


### PR DESCRIPTION
## Description

* Refactor the font selection UI in `configGeneral.qml` to improve usability.
* Replace the `ComboBox` used for font selection with a `TextField` and popup suggestion list.
* Allow users to search and filter available font families dynamically.
* Add a `filterFonts` function to filter font families based on user input.
* Limit search results to 50 fonts to improve performance and usability.
* Display a set of default fonts when the search field is empty.
* Implement keyboard navigation for the suggestion popup.
* Support `↓` to navigate suggestions.
* Support `Enter` to select a font.
* Support `Escape` to close the suggestion popup.
* Add a helper label explaining how to use the new font picker interface.

## Related Issue

Fixes #43 

## Testing

- [x] Tested on KDE Plasma 6.7.3
- [x] Distro: Fedora Linux 43
- [x] Widget installs cleanly with `install.sh`
- [x] Widget displays correctly in the panel

