### PR TITLE
fix: guard isMask/color init and sanitize custom colors (fix #73)

### DIFF
--- a/contents/ui/CompactView.qml
+++ b/contents/ui/CompactView.qml
@@ -23,6 +23,17 @@ RowLayout {
 
     readonly property bool isVertical: layoutType === "vertical"
 
+    // Defers isMask+color on Kirigami.Icon items until after the Plasma startup
+    // window-attachment sequence (ShellCorona::addOutput) completes. This prevents
+    // PlatformThemeData::setColor from being called while uninitialized (SIGSEGV #41).
+    property bool _themeReady: false
+    Timer {
+        interval: 0
+        repeat: false
+        running: true
+        onTriggered: compactRow._themeReady = true
+    }
+
     signal toggleExpanded()
 
     // Sticky-width state, keyed by a stable per-item/per-segment string
@@ -147,8 +158,8 @@ RowLayout {
                     }
                     delegate: Kirigami.Icon {
                         source: modelData
-                        isMask: true
-                        color: compactRow.iconColor
+                        isMask: compactRow._themeReady
+                        color: compactRow._themeReady ? compactRow.iconColor : Qt.rgba(0, 0, 0, 0)
                         width: compactRow.iconSize
                         height: compactRow.iconSize
                     }
@@ -257,8 +268,8 @@ RowLayout {
                             }
                             delegate: Kirigami.Icon {
                                 source: modelData
-                                isMask: true
-                                color: compactRow.iconColor
+                                isMask: compactRow._themeReady
+                                color: compactRow._themeReady ? compactRow.iconColor : Qt.rgba(0, 0, 0, 0)
                                 width:  Math.round(compactRow.iconSize * 0.85)
                                 height: Math.round(compactRow.iconSize * 0.85)
                             }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -164,12 +164,16 @@ PlasmoidItem {
 
     // --- Color configuration properties ---
 
+    function isValidColor(s) {
+        return typeof s === "string" && /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(s);
+    }
+
     property bool useCustomColors: Plasmoid.configuration.useCustomColors
     property string fontColor: Plasmoid.configuration.fontColor
     property string labelColor: Plasmoid.configuration.labelColor || ""
-    property color resolvedLabelColor: (useCustomColors && labelColor) ? labelColor : baseTextColor
+    property color resolvedLabelColor: (useCustomColors && isValidColor(labelColor)) ? labelColor : baseTextColor
     property string iconColor: Plasmoid.configuration.iconColor || ""
-    property color resolvedIconColor: (useCustomColors && iconColor) ? iconColor : resolvedLabelColor
+    property color resolvedIconColor: (useCustomColors && isValidColor(iconColor)) ? iconColor : resolvedLabelColor
     property bool enableThresholdColors: Plasmoid.configuration.enableThresholdColors
     property string warningColor: Plasmoid.configuration.warningColor || "#e5a50a"
     property string criticalColor: Plasmoid.configuration.criticalColor || "#da4453"
@@ -193,7 +197,7 @@ PlasmoidItem {
     property int diskTempWarningThreshold: Plasmoid.configuration.diskTempWarningThreshold
     property int diskTempCriticalThreshold: Plasmoid.configuration.diskTempCriticalThreshold
 
-    property color baseTextColor: (useCustomColors && fontColor !== "") ? fontColor : Kirigami.Theme.textColor
+    property color baseTextColor: (useCustomColors && isValidColor(fontColor)) ? fontColor : Kirigami.Theme.textColor
 
     // --- Pre-resolved per-metric colors ---
 

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -154,8 +154,8 @@ PlasmoidItem {
             case "temp":   return tempEnabled && temp.tempValue && temp.tempValue !== "--";
             case "gpu":    return gpuEnabled   && gpu.hasGpuData;
             case "bat":    return batEnabled   && battery.batValue;
-            case "net":    return netEnabled;
-            case "disk":   return diskEnabled;
+            case "net":    return netEnabled   && _sensorsReady;
+            case "disk":   return diskEnabled  && _sensorsReady;
             case "fan":    return fanEnabled   && fans.hasFanData;
             case "uptime": return uptimeEnabled && uptime.uptimeValue;
         }

--- a/contents/ui/sensors/DiskSensors.qml
+++ b/contents/ui/sensors/DiskSensors.qml
@@ -29,6 +29,24 @@ Item {
 
     property real _diskTempNum: NaN
 
+    // Defer SensorDataModel subscriptions until ksystemstats' disk plugin has settled.
+    property bool _bootReady: false
+    Timer {
+        interval: 500
+        repeat: false
+        running: true
+        onTriggered: root._bootReady = true
+    }
+
+    // Defer P5Support.DataSource (hotplug) until Solid/UDisks2 is fully ready.
+    property bool _hotplugReady: false
+    Timer {
+        interval: 1000
+        repeat: false
+        running: true
+        onTriggered: root._hotplugReady = true
+    }
+
     // Aggregate I/O sensors (used in compact panel and tooltip)
     Sensors.Sensor {
         id: diskReadSensor
@@ -87,9 +105,9 @@ Item {
 
     Connections {
         target: flatSensors
-        function onRowsInserted() { root._discoveryDirty = true; }
-        function onRowsRemoved()  { root._discoveryDirty = true; }
-        function onModelReset()   { root._discoveryDirty = true; }
+        function onRowsInserted() { root._discoveryDirty = true; root._tempDiscoveryDirty = true; }
+        function onRowsRemoved()  { root._discoveryDirty = true; root._tempDiscoveryDirty = true; }
+        function onModelReset()   { root._discoveryDirty = true; root._tempDiscoveryDirty = true; }
         function onDataChanged()  { root._discoveryDirty = true; }
     }
 
@@ -110,7 +128,7 @@ Item {
         id: diskData
         sensors: root._activeSensorIds
         updateRateLimit: root.updateInterval
-        enabled: root._activeSensorIds.length > 0
+        enabled: root._bootReady && root._activeSensorIds.length > 0
         onDataChanged: root.aggregatePerDisk()
         onReadyChanged: { if (ready) root.aggregatePerDisk(); }
     }
@@ -164,21 +182,23 @@ Item {
         return m ? m[1] : "";
     }
 
-    P5Support.DataSource {
-        id: hotplugSource
-        engine: "hotplug"
-        onSourceAdded: function(source) {
-            var disk = root._udiToDisk(source);
-            if (disk && root._unplugged[disk]) {
-                delete root._unplugged[disk];
-                root.refreshDiscovered();
+    Loader {
+        active: root._hotplugReady
+        sourceComponent: P5Support.DataSource {
+            engine: "hotplug"
+            onSourceAdded: function(source) {
+                var disk = root._udiToDisk(source);
+                if (disk && root._unplugged[disk]) {
+                    delete root._unplugged[disk];
+                    root.refreshDiscovered();
+                }
             }
-        }
-        onSourceRemoved: function(source) {
-            var disk = root._udiToDisk(source);
-            if (disk) {
-                root._unplugged[disk] = true;
-                root.refreshDiscovered();
+            onSourceRemoved: function(source) {
+                var disk = root._udiToDisk(source);
+                if (disk) {
+                    root._unplugged[disk] = true;
+                    root.refreshDiscovered();
+                }
             }
         }
     }
@@ -214,18 +234,11 @@ Item {
         }
     }
 
-    Connections {
-        target: flatSensors
-        function onRowsInserted() { root._tempDiscoveryDirty = true; }
-        function onRowsRemoved()  { root._tempDiscoveryDirty = true; }
-        function onModelReset()   { root._tempDiscoveryDirty = true; }
-    }
-
     Sensors.SensorDataModel {
         id: tempData
         sensors: root._tempSensorIds
         updateRateLimit: root.updateInterval
-        enabled: root._tempSensorIds.length > 0
+        enabled: root._bootReady && root._tempSensorIds.length > 0
         onDataChanged: root._aggregateTemp()
         onReadyChanged: { if (ready) root._aggregateTemp(); }
     }

--- a/contents/ui/sensors/NetworkSensors.qml
+++ b/contents/ui/sensors/NetworkSensors.qml
@@ -30,6 +30,15 @@ Item {
     property string _activeIface: ""
     property var _discoveredIfaces: []
 
+    // Defer IP-discovery SensorDataModel until ksystemstats' network plugin has settled.
+    property bool _bootReady: false
+    Timer {
+        interval: 500
+        repeat: false
+        running: true
+        onTriggered: root._bootReady = true
+    }
+
     Sensors.SensorTreeModel { id: sensorTree }
 
     KItemModels.KDescendantsProxyModel {
@@ -92,7 +101,8 @@ Item {
         id: ipDiscoveryModel
         sensors: root._ipSensorIds
         updateRateLimit: root.updateInterval
-        enabled: root._ipSensorIds.length > 0
+        enabled: root._bootReady
+                 && root._ipSensorIds.length > 0
                  && (root.networkInterface === "auto" || root.networkInterface === "")
 
         onDataChanged: root._resolveActiveIface()


### PR DESCRIPTION
## Description

- CompactView: defer isMask+color on Kirigami.Icon until _themeReady (0ms Timer), preventing syncColors/PlatformThemeData crash at startup.
- main.qml: add isValidColor() hex regex guard on fontColor, labelColor, and iconColor to prevent invalid QColor from reaching Kirigami.

## Related Issue

Fixes #73

## Testing

- [x] Tested on KDE 6.7.3
- [x] Distro: Fedora 43
- [x] Widget installs cleanly with `install.sh`
- [x] Widget displays correctly in the panel
