### PR TITLE
fix: resolve startup crashes and layout instabilities in 2.13.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to KVitals will be documented in this file.
 
+## [2.13.1] - 2026-07-31
+
+### Fixed
+
+- **Startup SIGSEGV on boot** (#73): Resolved a `SEGV_ACCERR` crash triggered when KActivities became ready and libPlasmaQuick parented the applet into the panel. `refWindow` propagated down the item tree and hit `KirigamiPlasmaStyle::setTextColor` on uninitialized `PlatformThemeData` objects. The `isEnabled()` guards for Network and Disk metrics now also check `_sensorsReady`, matching the existing pattern used by CPU, RAM, GPU, Fan, and Uptime.
+- **Kirigami icon crash at startup** (#73): `isMask` and the icon `color` property on `Kirigami.Icon` are no longer set immediately at component creation. Both are now applied inside a 0 ms `Timer` that fires only after `_themeReady`, preventing `syncColors`/`PlatformThemeData` from accessing a partially-initialized theme object during startup.
+- **Invalid QColor reaching Kirigami** (#73): Added `isValidColor()` hex-regex validation in `main.qml` for `fontColor`, `labelColor`, and `iconColor` config properties. Corrupt or empty color strings stored in the config no longer propagate to Kirigami color bindings.
+- **Disk sensor crash on boot** (#73): `SensorDataModel` instances for disk I/O and disk temperature are now gated behind a 500 ms `_bootReady` timer so the `ksystemstats` disk plugin has time to settle before KVitals subscribes to its D-Bus sensors.
+- **Network sensor crash on boot** (#73): The IP-discovery `SensorTreeModel` is similarly gated behind a 500 ms `_bootReady` timer, preventing rapid `rowsInserted` events during boot from triggering D-Bus re-subscriptions while the network plugin is still initialising.
+- **Solid/UDisks2 hotplug crash on boot** (#73): The `P5Support.DataSource` used for USB hotplug detection is now wrapped in a `Loader` activated only after a 1000 ms `_hotplugReady` timer, keeping it out of plasmashell's startup window entirely.
+- **Compact panel font family binding loop**: Resolved a self-referential `font.family` binding cycle in `CompactView` that triggered runtime QML loop warnings. The fallback now binds directly to `Kirigami.Theme.defaultFont.family`.
+- **Custom font discarded at system-default size**: The font family was previously skipped when `effectiveFontSize` was 0 (system default). Family and size are now applied independently so a custom font family is always honoured regardless of the chosen size.
+- **Panel reflow oscillations**: The `_stickyWidth` cache in `CompactView` now enforces a strict grow-only policy (the previous shrink threshold is removed), eliminating layout oscillations caused by fluctuating text metrics.
+- **Duplicate Connections blocks in DiskSensors**: Merged two separate `Connections { target: flatSensors }` blocks into one, halving the number of signal connections on the sensor model.
+
 ## [2.13.0] - 2026-07-23
 
 ### Added

--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,7 @@
     ],
     "Website": "https://github.com/yassine20011/kvitals",
     "BugReportUrl": "https://github.com/yassine20011/kvitals/issues",
-    "Version": "2.13.0",
+    "Version": "2.13.1",
     "License": "GPL-3.0"
   },
   "KPackageStructure": "Plasma/Applet",


### PR DESCRIPTION
## Description

This pull request releases version 2.13.1 of KVitals, focusing on fixing several startup crashes, color validation issues, and UI glitches. The update introduces multiple stability improvements and bug fixes, particularly around boot-time sensor initialization and QML property bindings.

Bug fixes and stability improvements:

* Fixed a `SEGV_ACCERR` crash at startup by improving initialization checks and guarding sensor readiness for Network and Disk metrics.
* Addressed a Kirigami icon crash at startup by deferring `isMask` and `color` property assignments until after the theme is fully initialized.
* Added hex-regex validation for color configuration properties to prevent invalid colors from propagating to Kirigami.
* Gated Disk and Network sensor model initialization behind startup timers to prevent crashes due to premature D-Bus subscriptions.
* Deferred USB hotplug detection initialization to avoid startup-time crashes related to Solid/UDisks2 plugins.

UI and configuration fixes:

* Resolved a font family binding loop and ensured custom font families are always applied, even at system-default sizes.
* Improved panel layout stability by refining width cache logic in `CompactView`.
* Merged duplicate signal connections in the disk sensor model to reduce overhead.

Other changes:

* Updated the version number to `2.13.1` in `metadata.json`.
