### PR TITLE
feat(models): harden MetricStore boundary and formalize metric contract

### DIFF
--- a/contents/ui/models/MetricStore.qml
+++ b/contents/ui/models/MetricStore.qml
@@ -30,11 +30,26 @@ Item {
         return chartHistory[key];
     }
 
-    // Appends val to the chartKey ring buffer. Returns false without writing if
-    // val is not a finite non-negative number.
+    // Normalizes input to a finite numeric scalar or NaN sentinel
+    function _normalizeValue(val) {
+        if (typeof val === "number" && isFinite(val) && !isNaN(val))
+            return val;
+        return NaN;
+    }
+
+    // Normalizes input to string
+    function _normalizeString(val, fallback) {
+        if (typeof val === "string")
+            return val;
+        if (val !== undefined && val !== null)
+            return String(val);
+        return fallback !== undefined ? fallback : "";
+    }
+
+    // Appends val to the chartKey ring buffer. Rejects non-finite numbers.
     function _pushHistory(key, val) {
-        if (!key) return false;
-        if (typeof val !== "number" || isNaN(val) || val < 0) return false;
+        if (!key || typeof key !== "string") return false;
+        if (typeof val !== "number" || isNaN(val) || !isFinite(val)) return false;
         if (!chartHistory[key]) chartHistory[key] = [];
         chartHistory[key].push(val);
         if (chartHistory[key].length > maxChartPoints) chartHistory[key].shift();
@@ -51,7 +66,7 @@ Item {
             var changed = false;
             for (var i = 0; i < list.length; i++) {
                 var m = list[i];
-                if (m.hasChart && m.chartKey && typeof m.value === "number") {
+                if (m.hasChart && m.chartKey && typeof m.value === "number" && isFinite(m.value) && !isNaN(m.value)) {
                     if (root._pushHistory(m.chartKey, m.value))
                         changed = true;
                 }
@@ -60,11 +75,9 @@ Item {
         }
     }
 
-    // _resolveMetricColor picks a color based on the numeric value and the
-    // metric's threshold settings. Returns baseTextColor when threshold colors
-    // are off, the type is "none", or the value is not a number.
+    // Resolves color based on numeric value and threshold settings
     function _resolveMetricColor(numVal, thresholdType, thresholdKey) {
-        if (!root.config || !root.config.enableThresholdColors || thresholdType === "none" || isNaN(numVal))
+        if (!root.config || !root.config.enableThresholdColors || thresholdType === "none" || typeof numVal !== "number" || isNaN(numVal) || !isFinite(numVal))
             return root.baseTextColor;
 
         var warn = root.config.getWarningThreshold(thresholdKey);
@@ -74,51 +87,51 @@ Item {
         return Utils.resolveColor(numVal, warn, crit, root.config.warningColor, root.config.criticalColor, root.baseTextColor, inverted);
     }
 
-    // _createMetric builds one metric object from a DEFINITIONS entry and a set
-    // of runtime overrides from the sensor layer. Override fields always win.
-    //
-    // The returned object shape is the metric "struct" used everywhere else:
-    //   id, defId, group, subKey, deviceId, deviceName
-    //   label, groupLabel, subLabel, prefix
-    //   icon, secondaryIcon
-    //   value (numeric), displayValue (string), popupDisplay, rawString
-    //   color, status
-    //   chartKey, chartMax, hasChart
-    //   visibleInCompact, visibleInPopup
+    // Constructs a normalized metric object conforming to the Metric Contract
     function _createMetric(defId, overrides) {
+        overrides = overrides || {};
         var def = Defs.DEFINITIONS[defId] || {};
         var cfg = root.config;
-        var group = overrides.group || def.group;
-        var subKey = overrides.subKey || def.subKey;
-        var rawVal = overrides.value !== undefined ? overrides.value : NaN;
+        var group = _normalizeString(overrides.group || def.group, "");
+        var subKey = _normalizeString(overrides.subKey || def.subKey, "");
+        var rawVal = _normalizeValue(overrides.value);
         var threshType = def.thresholdType || "none";
         var threshKey = def.thresholdKey || group;
         var clr = overrides.color !== undefined ? overrides.color : _resolveMetricColor(rawVal, threshType, threshKey);
         var defIcon = def.iconOverrideKey ? cfg[def.iconOverrideKey] : cfg.getGroupIcon(group);
 
-        var devId = overrides.deviceId || "";
+        var displayVal = _normalizeString(overrides.displayValue, "");
+        var popupDisplay = _normalizeString(overrides.popupDisplay, displayVal);
+        var rawStr = _normalizeString(overrides.rawString, displayVal);
+        var chartKey = overrides.chartKey !== undefined ? _normalizeString(overrides.chartKey, "") : (def.chartKey || "");
+        var chartMax = typeof overrides.chartMax === "number" && isFinite(overrides.chartMax) ? overrides.chartMax : (def.chartMax || 0);
+        var hasChart = Boolean(chartKey && chartKey.length > 0);
+
+        var devId = _normalizeString(overrides.deviceId, "");
+        var devName = _normalizeString(overrides.deviceName, "");
+
         return {
-            id: overrides.id || def.id,
+            id: _normalizeString(overrides.id, def.id || defId),
             defId: defId,
             group: group,
             subKey: subKey,
             deviceId: devId,
-            deviceName: overrides.deviceName || "",
-            label: overrides.label || (group === "ram" && subKey === "percentage" ? cfg.ramLabel : (cfg.getGroupLabel(group) + " " + def.label)),
-            groupLabel: overrides.groupLabel || cfg.getGroupLabel(group),
-            subLabel: overrides.subLabel !== undefined ? overrides.subLabel : (def.prefix || ""),
-            prefix: overrides.prefix !== undefined ? overrides.prefix : (def.prefix || ""),
+            deviceName: devName,
+            label: _normalizeString(overrides.label, (group === "ram" && subKey === "percentage" ? cfg.ramLabel : (cfg.getGroupLabel(group) + " " + def.label))),
+            groupLabel: _normalizeString(overrides.groupLabel, cfg.getGroupLabel(group)),
+            subLabel: _normalizeString(overrides.subLabel !== undefined ? overrides.subLabel : (def.prefix || ""), ""),
+            prefix: _normalizeString(overrides.prefix !== undefined ? overrides.prefix : (def.prefix || ""), ""),
             icon: overrides.icon || defIcon,
             secondaryIcon: overrides.secondaryIcon !== undefined ? overrides.secondaryIcon : (def.secondaryIcon ? cfg.tempIcon : ""),
             value: rawVal,
-            displayValue: overrides.displayValue || "",
-            popupDisplay: overrides.popupDisplay || overrides.displayValue || "",
-            rawString: overrides.rawString || overrides.displayValue || "",
+            displayValue: displayVal,
+            popupDisplay: popupDisplay,
+            rawString: rawStr,
             color: clr,
-            status: overrides.status || "ready",
-            chartKey: overrides.chartKey !== undefined ? overrides.chartKey : (def.chartKey || ""),
-            chartMax: overrides.chartMax !== undefined ? overrides.chartMax : (def.chartMax || 0),
-            hasChart: def.chartKey && def.chartKey.length > 0,
+            status: _normalizeString(overrides.status, "ready"),
+            chartKey: chartKey,
+            chartMax: chartMax,
+            hasChart: hasChart,
             visibleInCompact: cfg.isMetricVisible(group, subKey, "compact", devId),
             visibleInPopup: cfg.isMetricVisible(group, subKey, "widget", devId)
         };

--- a/contents/ui/sensors/Utils.qml
+++ b/contents/ui/sensors/Utils.qml
@@ -100,7 +100,7 @@ QtObject {
 
     function resolveColor(numericValue, warningThreshold, criticalThreshold,
                           warningColor, criticalColor, baseColor, inverted) {
-        if (isNaN(numericValue))
+        if (typeof numericValue !== "number" || isNaN(numericValue) || !isFinite(numericValue))
             return baseColor;
         if (inverted) {
             if (numericValue <= criticalThreshold) return criticalColor;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,30 +74,231 @@ A `QtObject` that wraps every `Plasmoid.configuration` value and provides typed 
 
 ### `MetricStore.qml`
 
-The central aggregator. On every sensor change it recomputes `metrics`, a `readonly` property holding a flat array of metric objects. Each object has a fixed shape:
+The central aggregator. On every sensor change it recomputes `metrics`, a `readonly` property holding a flat array of metric objects conforming to the Metric Contract.
+
+`MetricStore` also manages `chartHistory`, a ring buffer (up to 60 samples) per `chartKey`, written by `chartTimer` at `updateInterval` ms.
+
+## Metric Contract
+
+`MetricStore` serves as the normalization boundary between sensor modules and generic views:
 
 ```
-{
-  id, defId, group, subKey, deviceId, deviceName,
-  label, groupLabel, subLabel, prefix,
-  icon, secondaryIcon,
-  value,        // numeric (NaN when unavailable)
-  displayValue, // formatted string
-  popupDisplay, rawString,
-  color, status,
-  chartKey, chartMax, hasChart,
-  visibleInCompact, visibleInPopup
+Sensor QML Modules
+    ↓
+normalized metric
+    ↓
+MetricStore
+    ↓
+generic presentation (ViewHelpers / CompactView / FullView)
+```
+
+KVitals supports arbitrary metric sources as long as sensor modules normalize their data into the Metric Contract. Sensor components convert backend-specific structures (D-Bus objects, sysfs strings, boolean flags, or structured records) into numeric values or display strings before passing them to `MetricStore`:
+
+```
+D-Bus object / sysfs string / boolean state / structured backend value
+    ↓
+sensor-specific interpretation (polling, calculations, formatting)
+    ↓
+number or display string
+    ↓
+MetricStore (_createMetric normalization)
+```
+
+### Supported Metric Categories
+
+Every metric emitted by `MetricStore` falls into one of two categories:
+
+#### 1. Quantitative Metric
+Represents a scalar numeric measurement (percentages, rates, temperatures, frequencies, capacity, RPM, power).
+
+- `value`: Finite numeric scalar (`typeof value === "number" && isFinite(value)`). Set to `NaN` when temporarily loading or unavailable.
+- `displayValue`: Formatted string (e.g. `" 42%"`, `"55°C"`, `"16.4/32.0G"`).
+- `status`: `"ready"`, `"loading"`, or `"unavailable"`.
+- `hasChart`: `true` if `chartKey` is configured.
+- `chartKey`: Buffer identifier in `chartHistory`.
+- `chartMax`: Upper bound for chart scaling (`0` for auto-scale).
+- Thresholds: Warning and critical thresholds evaluate only against finite numeric values.
+
+MetricStore accepts finite numeric scalars, including negative values. Whether negative values are meaningful depends on the metric's domain semantics (such as battery charge/discharge rates, energy flow, or temperature deltas); sensor modules and metric definitions determine the appropriate interpretation.
+
+#### 2. Display-Only Metric
+Represents discrete text data without scalar telemetry (IP addresses, uptime strings).
+
+- `value`: `NaN` (explicit sentinel).
+- `displayValue`: Formatted string (e.g. `"192.168.1.10"`, `"2d 4h 12m"`).
+- `status`: `"ready"`, `"loading"`, or `"unavailable"`.
+- `hasChart`: `false` (`chartKey: ""`).
+- Thresholds: Not evaluated; retains base text color.
+- Chart history: Never enters `chartHistory`.
+
+### Normalization Rules
+
+`MetricStore._createMetric` enforces these normalization guarantees:
+
+1. **Finite number**: Preserved as the quantitative `value` (including negative numbers).
+2. **NaN**: Preserved as the non-quantitative or unavailable sentinel.
+3. **Infinity / -Infinity**: Normalized to `NaN`.
+4. **null / undefined**: Normalized to `NaN` (prevents coercion to 0).
+5. **boolean**: Normalized to `NaN` (prevents coercion to 0 or 1).
+6. **objects / arrays**: Normalized to `NaN`.
+7. **numeric strings**: Strings are never coerced into quantitative numbers; they are rejected to `NaN`.
+8. **displayValue**: Always normalized to a `string`.
+
+### Developer Examples
+
+#### Example 1: Quantitative Metric (Swap Usage)
+
+1. **MetricDefinitions.js**:
+```javascript
+"swap.usage": {
+    id: "swap.usage",
+    group: "ram",
+    subKey: "swap",
+    sensorId: "memory/swap/used",
+    label: "Swap Usage",
+    chartKey: "swap",
+    chartMax: 100,
+    thresholdType: "normal",
+    thresholdKey: "ram"
 }
 ```
 
-`MetricStore` also manages `chartHistory` — a ring buffer (up to 60 samples) per `chartKey`, written by `chartTimer` at `updateInterval` ms.
+2. **Sensor module (`MemorySensors.qml`)**:
+```qml
+Sensors.Sensor {
+    id: swapUsedSensor
+    sensorId: "memory/swap/used"
+    updateRateLimit: root.updateInterval
+}
+Sensors.Sensor {
+    id: swapTotalSensor
+    sensorId: "memory/swap/total"
+    updateRateLimit: root.updateInterval
+}
+
+readonly property real swapPercentage: {
+    if (swapUsedSensor.status !== Sensors.Sensor.Ready || swapTotalSensor.status !== Sensors.Sensor.Ready)
+        return NaN;
+    if (swapTotalSensor.value <= 0) return NaN;
+    return (swapUsedSensor.value / swapTotalSensor.value) * 100;
+}
+
+readonly property string swapValue: {
+    if (isNaN(swapPercentage)) return "...";
+    return Math.round(swapPercentage) + "%";
+}
+```
+
+3. **MetricStore integration (`MetricStore.qml`)**:
+```qml
+list.push(_createMetric("swap.usage", {
+    value: s.memory.swapPercentage,
+    displayValue: s.memory.swapValue,
+    status: !isNaN(s.memory.swapPercentage) ? "ready" : "loading"
+}));
+```
+
+4. **Normalized metric object in `MetricStore.metrics`**:
+```javascript
+{
+    id: "swap.usage",
+    defId: "swap.usage",
+    group: "ram",
+    subKey: "swap",
+    label: "RAM Swap Usage",
+    groupLabel: "RAM",
+    subLabel: "",
+    prefix: "",
+    icon: "nvidia-ram-symbolic",
+    secondaryIcon: "",
+    value: 24.5,
+    displayValue: "25%",
+    popupDisplay: "25%",
+    rawString: "25%",
+    color: "#ffffff",
+    status: "ready",
+    chartKey: "swap",
+    chartMax: 100,
+    hasChart: true,
+    visibleInCompact: true,
+    visibleInPopup: true
+}
+```
+
+#### Example 2: Display-Only Metric (Local IP)
+
+1. **MetricDefinitions.js**:
+```javascript
+"net.ip": {
+    id: "net.ip",
+    group: "net",
+    subKey: "ip",
+    sensorPattern: "network/{id}/ipv4withPrefixLength",
+    label: "Local IP",
+    chartKey: "",
+    chartMax: 0,
+    thresholdType: "none"
+}
+```
+
+2. **Sensor module (`NetworkSensors.qml`)**:
+```qml
+readonly property string netIpValue: {
+    if (netIpSensor.status !== Sensors.Sensor.Ready) return "...";
+    var v = netIpSensor.value || "";
+    var slash = v.indexOf("/");
+    return slash >= 0 ? v.substring(0, slash) : v;
+}
+```
+
+3. **MetricStore integration (`MetricStore.qml`)**:
+```qml
+list.push(_createMetric("net.ip", {
+    displayValue: s.network.netIpValue,
+    status: "ready"
+}));
+```
+
+4. **Normalized metric object in `MetricStore.metrics`**:
+```javascript
+{
+    id: "net.ip",
+    defId: "net.ip",
+    group: "net",
+    subKey: "ip",
+    label: "NET Local IP",
+    groupLabel: "NET",
+    subLabel: "",
+    prefix: "",
+    icon: "network-wireless",
+    secondaryIcon: "",
+    value: NaN,
+    displayValue: "192.168.1.10",
+    popupDisplay: "192.168.1.10",
+    rawString: "192.168.1.10",
+    color: "#ffffff",
+    status: "ready",
+    chartKey: "",
+    chartMax: 0,
+    hasChart: false,
+    visibleInCompact: false,
+    visibleInPopup: true
+}
+```
+
+### Architectural Roles
+
+- **HardwareDiscovery**: *"What sensors exist?"* (topology and IDs)
+- **Sensor modules**: *"What does this sensor mean?"* (polling, calculations, and domain formatting)
+- **MetricStore**: *"How do I normalize and expose this metric?"* (contract enforcement, thresholds, chart history)
+- **ViewHelpers / Views**: *"How do I present the metric?"* (generic layout and presentation)
 
 ### `ViewHelpers.js`
 
 A `.pragma library` file with two functions:
 
-- `buildCompactItems(metricsList, orderedKeys)` — groups and orders metrics into compact panel items. Items are either `{ icon, label, value, color, key }` (single value) or `{ icon, label, segments, color, key }` (multi-value, used for net, disk, multi-fan).
-- `buildPopupItems(metricsList, orderedKeys)` — returns one row per visible popup metric: `{ label, value, color, icon, chartKey, chartMax }`. `icon` may be a two-element array when a secondary icon is present.
+- `buildCompactItems(metricsList, orderedKeys)`: groups and orders metrics into compact panel items. Items are either `{ icon, label, value, color, key }` (single value) or `{ icon, label, segments, color, key }` (multi-value, used for net, disk, multi-fan).
+- `buildPopupItems(metricsList, orderedKeys)`: returns one row per visible popup metric: `{ label, value, color, icon, chartKey, chartMax }`. `icon` may be a two-element array when a secondary icon is present.
 
 ## Views
 


### PR DESCRIPTION
## Description

Hardens the `MetricStore` normalization boundary and formalizes the Metric Contract for KVitals.

### Summary of Changes
- **Type-safe Normalization**:
  - `MetricStore._createMetric` normalizes `value` to finite numeric scalars (`typeof value === "number" && isFinite(value)`), rejecting non-finite values (`null`, `undefined`, `boolean`, `object`, `array`, `numeric string`, `Infinity`, `-Infinity`) to `NaN`.
  - Ensures `displayValue`, `popupDisplay`, and `rawString` are always normalized strings.
- **Threshold & Chart Guarding**:
  - `_resolveMetricColor()` and `_pushHistory()` now strictly require finite numbers, preventing coercion bugs where `null` or `false` could trigger inverted critical thresholds or `Infinity` could corrupt sparkline scaling.
  - `Utils.resolveColor()` defensively validates numeric types.
- **Architecture Documentation**:
  - Added a dedicated **Metric Contract** section in `docs/architecture.md` detailing the 4-stage pipeline, quantitative vs. display-only metrics, type vs. domain semantics, and developer examples for Swap Usage and Local IP.

## Related Issue

Part of the data-driven metric architecture and hardware discovery refactor (stacked on #83).
