### PR TITLE
feat: add dedicated Swap sensor module and metrics

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -28,6 +28,15 @@
         <entry name="ramVisibility" type="String">
             <default>both</default>
         </entry>
+        <entry name="swapEnabled" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="swapSubMetrics" type="String">
+            <default>percent,used</default>
+        </entry>
+        <entry name="swapVisibility" type="String">
+            <default>both</default>
+        </entry>
         <entry name="tempEnabled" type="Bool">
             <default>true</default>
         </entry>
@@ -93,6 +102,9 @@
         <entry name="ramLabel" type="String">
             <default>RAM</default>
         </entry>
+        <entry name="swapLabel" type="String">
+            <default>SWAP</default>
+        </entry>
         <entry name="diskLabel" type="String">
             <default>DSK</default>
         </entry>
@@ -136,6 +148,9 @@
         <entry name="ramIcon" type="String">
             <default>nvidia-ram-symbolic</default>
         </entry>
+        <entry name="swapIcon" type="String">
+            <default>nvidia-ram-symbolic</default>
+        </entry>
         <entry name="tempIcon" type="String">
             <default>temperature-normal</default>
         </entry>
@@ -174,7 +189,7 @@
 
         <!-- Order -->
         <entry name="metricOrder" type="String">
-            <default>cpu,ram,temp,gpu,bat,net,disk,fan,uptime</default>
+            <default>cpu,ram,swap,temp,gpu,bat,net,disk,fan,uptime</default>
         </entry>
 
         <!-- Timing -->
@@ -226,6 +241,12 @@
             <default>70</default>
         </entry>
         <entry name="ramCriticalThreshold" type="Int">
+            <default>90</default>
+        </entry>
+        <entry name="swapWarningThreshold" type="Int">
+            <default>70</default>
+        </entry>
+        <entry name="swapCriticalThreshold" type="Int">
             <default>90</default>
         </entry>
         <entry name="ramTempWarningThreshold" type="Int">

--- a/contents/ui/configColors.qml
+++ b/contents/ui/configColors.qml
@@ -24,6 +24,8 @@ KCM.SimpleKCM {
     property alias cfg_systemCriticalThreshold: systemCritSlider.value
     property alias cfg_ramWarningThreshold: ramWarnSlider.value
     property alias cfg_ramCriticalThreshold: ramCritSlider.value
+    property alias cfg_swapWarningThreshold: swapWarnSlider.value
+    property alias cfg_swapCriticalThreshold: swapCritSlider.value
     property alias cfg_ramTempWarningThreshold: ramTempWarnSlider.value
     property alias cfg_ramTempCriticalThreshold: ramTempCritSlider.value
     property alias cfg_gpuWarningThreshold: gpuWarnSlider.value
@@ -480,6 +482,20 @@ KCM.SimpleKCM {
             }
             Rectangle { Layout.preferredWidth: 10; Layout.preferredHeight: 10; radius: 5; color: ramWarnSlider.value >= ramCritSlider.value ? cfg_criticalColor : "transparent" }
 
+            // --- Swap Usage ---
+            Label { text: i18n("Swap Usage") }
+            RowLayout {
+                Layout.fillWidth: true
+                Slider { id: swapWarnSlider; from: 10; to: 100; stepSize: 5; value: 70; Layout.fillWidth: true }
+                Label { text: Math.round(swapWarnSlider.value) + "%"; Layout.preferredWidth: 40 }
+            }
+            RowLayout {
+                Layout.fillWidth: true
+                Slider { id: swapCritSlider; from: 10; to: 100; stepSize: 5; value: 90; Layout.fillWidth: true }
+                Label { text: Math.round(swapCritSlider.value) + "%"; Layout.preferredWidth: 40 }
+            }
+            Rectangle { Layout.preferredWidth: 10; Layout.preferredHeight: 10; radius: 5; color: swapWarnSlider.value >= swapCritSlider.value ? cfg_criticalColor : "transparent" }
+
             // --- RAM Temperature ---
             Label { text: i18n("RAM Temp") }
             RowLayout {
@@ -586,6 +602,7 @@ KCM.SimpleKCM {
                 tempWarnSlider.value = 60; tempCritSlider.value = 85
                 systemWarnSlider.value = 60; systemCritSlider.value = 85
                 ramWarnSlider.value = 70;  ramCritSlider.value = 90
+                swapWarnSlider.value = 70; swapCritSlider.value = 90
                 ramTempWarnSlider.value = 60; ramTempCritSlider.value = 85
                 gpuWarnSlider.value = 70;  gpuCritSlider.value = 90
                 gpuTempWarnSlider.value = 60; gpuTempCritSlider.value = 85

--- a/contents/ui/configIcons.qml
+++ b/contents/ui/configIcons.qml
@@ -26,6 +26,7 @@ KCM.SimpleKCM {
 
     property string cfg_cpuIcon: "am-cpu-symbolic"
     property string cfg_ramIcon: "nvidia-ram-symbolic"
+    property string cfg_swapIcon: "nvidia-ram-symbolic"
     property string cfg_tempIcon: "temperature-normal"
     property string cfg_gpuIcon: "gpu-symbolic"
     property string cfg_batteryIcon: "battery-good"
@@ -42,6 +43,10 @@ KCM.SimpleKCM {
     KIconThemes.IconDialog {
         id: ramIconDialog
         onIconNameChanged: if (iconName) cfg_ramIcon = iconName
+    }
+    KIconThemes.IconDialog {
+        id: swapIconDialog
+        onIconNameChanged: if (iconName) cfg_swapIcon = iconName
     }
     KIconThemes.IconDialog {
         id: tempIconDialog
@@ -89,6 +94,12 @@ KCM.SimpleKCM {
             Kirigami.FormData.label: i18n("RAM:")
             Kirigami.Icon { source: resolveIcon(cfg_ramIcon); isMask: true; Layout.preferredWidth: 22; Layout.preferredHeight: 22 }
             Button { text: i18n("Change..."); onClicked: ramIconDialog.open(); icon.name: "document-edit" }
+        }
+
+        RowLayout {
+            Kirigami.FormData.label: i18n("Swap:")
+            Kirigami.Icon { source: resolveIcon(cfg_swapIcon); isMask: true; Layout.preferredWidth: 22; Layout.preferredHeight: 22 }
+            Button { text: i18n("Change..."); onClicked: swapIconDialog.open(); icon.name: "document-edit" }
         }
 
         RowLayout {
@@ -146,6 +157,7 @@ KCM.SimpleKCM {
             onClicked: {
                 cfg_cpuIcon = "am-cpu-symbolic";
                 cfg_ramIcon = "nvidia-ram-symbolic";
+                cfg_swapIcon = "nvidia-ram-symbolic";
                 cfg_tempIcon = "temperature-normal";
                 cfg_gpuIcon = "gpu-symbolic";
                 cfg_batteryIcon = "battery-good";

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -25,6 +25,11 @@ KCM.SimpleKCM {
     property bool cfg_ramWidgetShowBoth: false
     property string cfg_ramVisibility: "both"
 
+    property bool cfg_swapEnabled
+    property string cfg_swapSubMetrics: MetricDefinitions.GROUPS.swap.defaultSubMetrics
+    property string cfg_swapLabel: "SWAP"
+    property string cfg_swapVisibility: "both"
+
     property bool cfg_tempEnabled
     property string cfg_tempLabel: "System"
     property string cfg_tempVisibility: "both"
@@ -60,13 +65,14 @@ KCM.SimpleKCM {
     property bool cfg_uptimeEnabled
     property string cfg_uptimeVisibility: "both"
 
-    property string cfg_metricOrder: "cpu,ram,temp,gpu,bat,net,disk,fan,uptime"
+    property string cfg_metricOrder: "cpu,ram,swap,temp,gpu,bat,net,disk,fan,uptime"
     property string cfg_batteryDevice
 
     // ── Icon bindings (from configIcons.qml, shared across config pages) ───
 
     property string cfg_cpuIcon:     "am-cpu-symbolic"
     property string cfg_ramIcon:     "nvidia-ram-symbolic"
+    property string cfg_swapIcon:    "nvidia-ram-symbolic"
     property string cfg_tempIcon:    "temperature-normal"
     property string cfg_gpuIcon:     "gpu-symbolic"
     property string cfg_batteryIcon: "battery-good"
@@ -78,7 +84,7 @@ KCM.SimpleKCM {
 
     // ── Category metadata ──────────────────────────────────────────────────
 
-    readonly property var allKeys: ["cpu", "ram", "temp", "gpu", "bat", "net", "disk", "fan", "uptime"]
+    readonly property var allKeys: ["cpu", "ram", "swap", "temp", "gpu", "bat", "net", "disk", "fan", "uptime"]
 
     function resolveIcon(name) {
         switch (name) {
@@ -98,6 +104,7 @@ KCM.SimpleKCM {
         switch (key) {
             case "cpu":    name = cfg_cpuIcon; break;
             case "ram":    name = cfg_ramIcon; break;
+            case "swap":   name = cfg_swapIcon; break;
             case "temp":   name = cfg_tempIcon; break;
             case "gpu":    name = cfg_gpuIcon; break;
             case "bat":    name = cfg_batteryIcon; break;
@@ -120,6 +127,12 @@ KCM.SimpleKCM {
             {key: "percentage", label: i18n("Percentage")},
             {key: "used",       label: i18n("Used / Total")},
             {key: "temp",       label: i18n("Temperature (DDR5)")}
+        ]},
+        "swap": { label: i18n("Swap"),             subs: [
+            {key: "percent", label: i18n("Usage (%)")},
+            {key: "used",    label: i18n("Used")},
+            {key: "free",    label: i18n("Free")},
+            {key: "total",   label: i18n("Total")}
         ]},
         "temp": { label: i18n("Temperature"),      subs: []},
         "gpu":  { label: i18n("GPU"),              subs: [
@@ -152,6 +165,7 @@ KCM.SimpleKCM {
         switch (key) {
             case "cpu":  str = cfg_cpuSubMetrics;  break;
             case "ram":  str = cfg_ramSubMetrics;  break;
+            case "swap": str = cfg_swapSubMetrics; break;
             case "gpu":  str = cfg_gpuSubMetrics;  break;
             case "bat":  str = cfg_batSubMetrics;  break;
             case "net":  str = cfg_netSubMetrics;  break;
@@ -165,6 +179,7 @@ KCM.SimpleKCM {
         switch (key) {
             case "cpu":    return cfg_cpuEnabled;
             case "ram":    return cfg_ramEnabled;
+            case "swap":   return cfg_swapEnabled;
             case "temp":   return cfg_tempEnabled;
             case "gpu":    return cfg_gpuEnabled;
             case "bat":    return cfg_batEnabled;
@@ -180,6 +195,7 @@ KCM.SimpleKCM {
         switch (key) {
             case "cpu":    cfg_cpuEnabled    = val; break;
             case "ram":    cfg_ramEnabled    = val; break;
+            case "swap":   cfg_swapEnabled   = val; break;
             case "temp":   cfg_tempEnabled   = val; break;
             case "gpu":    cfg_gpuEnabled    = val; break;
             case "bat":    cfg_batEnabled    = val; break;
@@ -194,6 +210,7 @@ KCM.SimpleKCM {
         switch (key) {
             case "cpu":    return cfg_cpuVisibility;
             case "ram":    return cfg_ramVisibility;
+            case "swap":   return cfg_swapVisibility;
             case "temp":   return cfg_tempVisibility;
             case "gpu":    return cfg_gpuVisibility;
             case "bat":    return cfg_batVisibility;
@@ -209,6 +226,7 @@ KCM.SimpleKCM {
         switch (key) {
             case "cpu":    cfg_cpuVisibility    = val; break;
             case "ram":    cfg_ramVisibility    = val; break;
+            case "swap":   cfg_swapVisibility   = val; break;
             case "temp":   cfg_tempVisibility   = val; break;
             case "gpu":    cfg_gpuVisibility    = val; break;
             case "bat":    cfg_batVisibility    = val; break;
@@ -233,6 +251,7 @@ KCM.SimpleKCM {
         switch (key) {
             case "cpu":  cfg_cpuSubMetrics  = str; break;
             case "ram":  cfg_ramSubMetrics  = str; break;
+            case "swap": cfg_swapSubMetrics = str; break;
             case "gpu":  cfg_gpuSubMetrics  = str; break;
             case "bat":  cfg_batSubMetrics  = str; break;
             case "net":  cfg_netSubMetrics  = str; break;
@@ -589,6 +608,7 @@ KCM.SimpleKCM {
                             // Label field
                             RowLayout {
                                 visible: catDelegate.key === "cpu" || catDelegate.key === "ram" ||
+                                         catDelegate.key === "swap" ||
                                          catDelegate.key === "net" || catDelegate.key === "disk"
                                 spacing: Kirigami.Units.smallSpacing
                                 Label { text: i18n("Label:"); opacity: 0.8 }
@@ -598,6 +618,7 @@ KCM.SimpleKCM {
                                         switch (catDelegate.key) {
                                             case "cpu":  return cfg_cpuLabel;
                                             case "ram":  return cfg_ramLabel;
+                                            case "swap": return cfg_swapLabel;
                                             case "net":  return cfg_netLabel;
                                             case "disk": return cfg_diskLabel;
                                         }
@@ -609,6 +630,7 @@ KCM.SimpleKCM {
                                         switch (catDelegate.key) {
                                             case "cpu":  cfg_cpuLabel  = v; break;
                                             case "ram":  cfg_ramLabel  = v; break;
+                                            case "swap": cfg_swapLabel = v; break;
                                             case "net":  cfg_netLabel  = v; break;
                                             case "disk": cfg_diskLabel = v; break;
                                         }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -64,6 +64,7 @@ PlasmoidItem {
             property alias discovery: _discovery
             property alias cpu:       _cpu
             property alias memory:    _memory
+            property alias swap:      _swap
             property alias temp:      _temp
             property alias gpu:       _gpu
             property alias battery:   _battery
@@ -83,6 +84,11 @@ PlasmoidItem {
 
             MemorySensors {
                 id: _memory
+                updateInterval: metricConfig.updateInterval
+            }
+
+            SwapSensors {
+                id: _swap
                 updateInterval: metricConfig.updateInterval
             }
 

--- a/contents/ui/models/MetricConfig.qml
+++ b/contents/ui/models/MetricConfig.qml
@@ -33,6 +33,7 @@ QtObject {
     // skipped by MetricStore and hidden from the config metrics page.
     readonly property bool cpuEnabled:    Plasmoid.configuration.cpuEnabled
     readonly property bool ramEnabled:    Plasmoid.configuration.ramEnabled
+    readonly property bool swapEnabled:   Plasmoid.configuration.swapEnabled
     readonly property bool tempEnabled:   Plasmoid.configuration.tempEnabled
     readonly property bool gpuEnabled:    Plasmoid.configuration.gpuEnabled
     readonly property bool batEnabled:    Plasmoid.configuration.batEnabled
@@ -45,6 +46,7 @@ QtObject {
         switch (group) {
         case "cpu":    return cpuEnabled;
         case "ram":    return ramEnabled;
+        case "swap":   return swapEnabled;
         case "temp":   return tempEnabled;
         case "gpu":    return gpuEnabled;
         case "bat":    return batEnabled;
@@ -59,6 +61,7 @@ QtObject {
     // Sub-metric comma-separated lists
     readonly property string cpuSubMetrics:  Plasmoid.configuration.cpuSubMetrics  || Defs.GROUPS.cpu.defaultSubMetrics
     readonly property string ramSubMetrics:  Plasmoid.configuration.ramSubMetrics  || Defs.GROUPS.ram.defaultSubMetrics
+    readonly property string swapSubMetrics: Plasmoid.configuration.swapSubMetrics || Defs.GROUPS.swap.defaultSubMetrics
     readonly property string gpuSubMetrics:  Plasmoid.configuration.gpuSubMetrics  || Defs.GROUPS.gpu.defaultSubMetrics
     readonly property string batSubMetrics:  Plasmoid.configuration.batSubMetrics  || Defs.GROUPS.bat.defaultSubMetrics
     readonly property string netSubMetrics:  Plasmoid.configuration.netSubMetrics  || Defs.GROUPS.net.defaultSubMetrics
@@ -68,6 +71,7 @@ QtObject {
     // or "both". isMetricVisible() enforces this per sub-metric.
     readonly property string cpuVisibility:    Plasmoid.configuration.cpuVisibility    || "both"
     readonly property string ramVisibility:    Plasmoid.configuration.ramVisibility    || "both"
+    readonly property string swapVisibility:   Plasmoid.configuration.swapVisibility   || "both"
     readonly property string tempVisibility:   Plasmoid.configuration.tempVisibility   || "both"
     readonly property string gpuVisibility:    Plasmoid.configuration.gpuVisibility    || "both"
     readonly property string batVisibility:    Plasmoid.configuration.batVisibility    || "both"
@@ -80,6 +84,7 @@ QtObject {
         switch (group) {
         case "cpu":    return cpuVisibility;
         case "ram":    return ramVisibility;
+        case "swap":   return swapVisibility;
         case "temp":   return tempVisibility;
         case "gpu":    return gpuVisibility;
         case "bat":    return batVisibility;
@@ -96,6 +101,7 @@ QtObject {
         switch (group) {
         case "cpu":  str = cpuSubMetrics; break;
         case "ram":  str = ramSubMetrics; break;
+        case "swap": str = swapSubMetrics; break;
         case "gpu":  str = gpuSubMetrics; break;
         case "bat":  str = batSubMetrics; break;
         case "net":  str = netSubMetrics; break;
@@ -147,6 +153,7 @@ QtObject {
     // Labels
     readonly property string cpuLabel:  Plasmoid.configuration.cpuLabel  || "CPU"
     readonly property string ramLabel:  Plasmoid.configuration.ramLabel  || "RAM"
+    readonly property string swapLabel: Plasmoid.configuration.swapLabel || "SWAP"
     readonly property string tempLabel: Plasmoid.configuration.tempLabel || "System"
     readonly property string netLabel:  Plasmoid.configuration.netLabel  || "NET"
     readonly property string diskLabel: Plasmoid.configuration.diskLabel || "DSK"
@@ -159,6 +166,7 @@ QtObject {
         switch (group) {
         case "cpu":    return cpuLabel;
         case "ram":    return ramLabel;
+        case "swap":   return swapLabel;
         case "temp":   return tempLabel;
         case "gpu":    return "GPU";
         case "bat":    return "BAT";
@@ -173,6 +181,7 @@ QtObject {
     // Icons
     readonly property string cpuIcon:     resolveIcon(Plasmoid.configuration.cpuIcon || "am-cpu-symbolic")
     readonly property string ramIcon:     resolveIcon(Plasmoid.configuration.ramIcon || "nvidia-ram-symbolic")
+    readonly property string swapIcon:    resolveIcon(Plasmoid.configuration.swapIcon || "nvidia-ram-symbolic")
     readonly property string tempIcon:    resolveIcon(Plasmoid.configuration.tempIcon || "temperature-normal")
     readonly property string gpuIcon:     resolveIcon(Plasmoid.configuration.gpuIcon || "gpu-symbolic")
     readonly property string batteryIcon: resolveIcon(Plasmoid.configuration.batteryIcon || "battery-good")
@@ -186,6 +195,7 @@ QtObject {
         switch (group) {
         case "cpu":    return cpuIcon;
         case "ram":    return ramIcon;
+        case "swap":   return swapIcon;
         case "temp":   return tempIcon;
         case "gpu":    return gpuIcon;
         case "bat":    return batteryIcon;
@@ -212,6 +222,8 @@ QtObject {
     readonly property int systemCriticalThreshold:  Plasmoid.configuration.systemCriticalThreshold  || 85
     readonly property int ramWarningThreshold:      Plasmoid.configuration.ramWarningThreshold      || 70
     readonly property int ramCriticalThreshold:     Plasmoid.configuration.ramCriticalThreshold     || 90
+    readonly property int swapWarningThreshold:     Plasmoid.configuration.swapWarningThreshold     || 70
+    readonly property int swapCriticalThreshold:    Plasmoid.configuration.swapCriticalThreshold    || 90
     readonly property int ramTempWarningThreshold:  Plasmoid.configuration.ramTempWarningThreshold  || 60
     readonly property int ramTempCriticalThreshold: Plasmoid.configuration.ramTempCriticalThreshold || 85
     readonly property int gpuWarningThreshold:      Plasmoid.configuration.gpuWarningThreshold      || 70

--- a/contents/ui/models/MetricDefinitions.js
+++ b/contents/ui/models/MetricDefinitions.js
@@ -16,6 +16,12 @@ var GROUPS = {
         defaultIcon: "nvidia-ram-symbolic",
         defaultSubMetrics: "percentage"
     },
+    swap: {
+        id: "swap",
+        defaultLabel: "SWAP",
+        defaultIcon: "nvidia-ram-symbolic",
+        defaultSubMetrics: "percent,used"
+    },
     temp: {
         id: "temp",
         defaultLabel: "System",
@@ -62,7 +68,7 @@ var GROUPS = {
 
 // Canonical display order. MetricConfig uses this list to fill any gaps left
 // by a partial metricOrder setting.
-var ALL_GROUP_KEYS = ["cpu", "ram", "temp", "gpu", "bat", "net", "disk", "fan", "uptime"];
+var ALL_GROUP_KEYS = ["cpu", "ram", "swap", "temp", "gpu", "bat", "net", "disk", "fan", "uptime"];
 
 // Canonical discovery patterns for dynamic hardware devices
 var PATTERNS = {
@@ -168,6 +174,47 @@ var DEFINITIONS = {
         thresholdType: "normal",
         thresholdKey: "ramTemp",
         secondaryIcon: "temperature-normal"
+    },
+    "swap.percent": {
+        id: "swap.percent",
+        group: "swap",
+        subKey: "percent",
+        sensorId: "memory/swap/usedPercent",
+        label: "Usage",
+        chartKey: "swap",
+        chartMax: 100,
+        thresholdType: "normal",
+        thresholdKey: "swap"
+    },
+    "swap.used": {
+        id: "swap.used",
+        group: "swap",
+        subKey: "used",
+        sensorId: "memory/swap/used",
+        label: "Used",
+        chartKey: "",
+        chartMax: 0,
+        thresholdType: "none"
+    },
+    "swap.free": {
+        id: "swap.free",
+        group: "swap",
+        subKey: "free",
+        sensorId: "memory/swap/free",
+        label: "Free",
+        chartKey: "",
+        chartMax: 0,
+        thresholdType: "none"
+    },
+    "swap.total": {
+        id: "swap.total",
+        group: "swap",
+        subKey: "total",
+        sensorId: "memory/swap/total",
+        label: "Total",
+        chartKey: "",
+        chartMax: 0,
+        thresholdType: "none"
     },
     "temp.system": {
         id: "temp.system",

--- a/contents/ui/models/MetricStore.qml
+++ b/contents/ui/models/MetricStore.qml
@@ -192,6 +192,37 @@ Item {
             }
         }
 
+        // Swap
+        if (cfg.isGroupEnabled("swap") && s.swap) {
+            list.push(_createMetric("swap.percent", {
+                value: s.swap.swapPercentage,
+                displayValue: s.swap.swapPercentValue,
+                label: cfg.swapLabel,
+                status: !isNaN(s.swap.swapPercentage) ? "ready" : (s.swap.swapAvailable ? "loading" : "unavailable")
+            }));
+
+            list.push(_createMetric("swap.used", {
+                value: s.swap.swapUsedRaw,
+                displayValue: s.swap.swapUsedValue,
+                label: cfg.swapLabel + " Used",
+                status: !isNaN(s.swap.swapUsedRaw) ? "ready" : (s.swap.swapAvailable ? "loading" : "unavailable")
+            }));
+
+            list.push(_createMetric("swap.free", {
+                value: s.swap.swapFreeRaw,
+                displayValue: s.swap.swapFreeValue,
+                label: cfg.swapLabel + " Free",
+                status: !isNaN(s.swap.swapFreeRaw) ? "ready" : (s.swap.swapAvailable ? "loading" : "unavailable")
+            }));
+
+            list.push(_createMetric("swap.total", {
+                value: s.swap.swapTotalRaw,
+                displayValue: s.swap.swapTotalValue,
+                label: cfg.swapLabel + " Total",
+                status: !isNaN(s.swap.swapTotalRaw) ? "ready" : (s.swap.swapAvailable ? "loading" : "unavailable")
+            }));
+        }
+
         // System Temperature
         if (cfg.isGroupEnabled("temp") && s.temp && s.temp.tempValue && s.temp.tempValue !== "--") {
             list.push(_createMetric("temp.system", {

--- a/contents/ui/sensors/SwapSensors.qml
+++ b/contents/ui/sensors/SwapSensors.qml
@@ -1,0 +1,45 @@
+import QtQuick
+import org.kde.ksysguard.sensors as Sensors
+
+Item {
+    id: root
+
+    property int updateInterval: 2000
+
+    readonly property bool swapAvailable: {
+        return swapTotalSensor.status === Sensors.Sensor.Ready && swapTotalSensor.value > 0;
+    }
+
+    readonly property real swapPercentage: {
+        if (!swapAvailable || swapUsedSensor.status !== Sensors.Sensor.Ready)
+            return NaN;
+        return (swapUsedSensor.value / swapTotalSensor.value) * 100;
+    }
+
+    readonly property real swapUsedRaw: (swapUsedSensor.status === Sensors.Sensor.Ready) ? swapUsedSensor.value : NaN
+    readonly property real swapFreeRaw: (swapFreeSensor.status === Sensors.Sensor.Ready) ? swapFreeSensor.value : NaN
+    readonly property real swapTotalRaw: (swapTotalSensor.status === Sensors.Sensor.Ready) ? swapTotalSensor.value : NaN
+
+    readonly property string swapPercentValue: isNaN(swapPercentage) ? "..." : Math.round(swapPercentage).toString().padStart(3) + "%"
+    readonly property string swapUsedValue: isNaN(swapUsedRaw) ? "..." : Utils.formatBytes(swapUsedRaw) + "G"
+    readonly property string swapFreeValue: isNaN(swapFreeRaw) ? "..." : Utils.formatBytes(swapFreeRaw) + "G"
+    readonly property string swapTotalValue: isNaN(swapTotalRaw) ? "..." : Utils.formatBytes(swapTotalRaw) + "G"
+
+    Sensors.Sensor {
+        id: swapUsedSensor
+        sensorId: "memory/swap/used"
+        updateRateLimit: root.updateInterval
+    }
+
+    Sensors.Sensor {
+        id: swapFreeSensor
+        sensorId: "memory/swap/free"
+        updateRateLimit: root.updateInterval
+    }
+
+    Sensors.Sensor {
+        id: swapTotalSensor
+        sensorId: "memory/swap/total"
+        updateRateLimit: root.updateInterval
+    }
+}

--- a/contents/ui/sensors/qmldir
+++ b/contents/ui/sensors/qmldir
@@ -2,6 +2,7 @@ module sensors
 singleton Utils 1.0 Utils.qml
 CpuSensors 1.0 CpuSensors.qml
 MemorySensors 1.0 MemorySensors.qml
+SwapSensors 1.0 SwapSensors.qml
 TempSensors 1.0 TempSensors.qml
 GpuSensors 1.0 GpuSensors.qml
 BatterySensors 1.0 BatterySensors.qml


### PR DESCRIPTION
## Description

Adds dedicated Swap monitoring support:

- Introduces `SwapSensors.qml` to query swap metrics (`memory/swap/used`, `free`, `total`, `usedPercent`) from `ksystemstats`.
- Exposes `swap.percent`, `swap.used`, `swap.free`, and `swap.total` through `MetricStore`.
- Adds full configuration support (enable/disable toggle, sub-metric selection, custom label, icon chooser, visibility target, and warning/critical threshold colors).
- Preserves view independence (`CompactView` and `FullView` adapt dynamically via `ViewHelpers`).

## Testing

- [x] Tested on KDE Plasma 6.7.4
- [x] Distro: Fedora Linux 44
- [x] Widget installs cleanly with `install.sh`
- [x] Widget displays correctly in the panel

## Screenshots

<img width="521" height="33" alt="image" src="https://github.com/user-attachments/assets/b4ccd06b-b5f1-466f-b736-02e04e308d07" />
