### PR TITLE
refactor(config): decouple configMetrics and make metric settings data-driven

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -273,6 +273,12 @@
         <entry name="batteryCriticalThreshold" type="Int">
             <default>15</default>
         </entry>
+        <entry name="diskWarningThreshold" type="Int">
+            <default>80</default>
+        </entry>
+        <entry name="diskCriticalThreshold" type="Int">
+            <default>90</default>
+        </entry>
         <entry name="diskTempWarningThreshold" type="Int">
             <default>45</default>
         </entry>

--- a/contents/ui/configColors.qml
+++ b/contents/ui/configColors.qml
@@ -34,6 +34,8 @@ KCM.SimpleKCM {
     property alias cfg_gpuTempCriticalThreshold: gpuTempCritSlider.value
     property alias cfg_batteryWarningThreshold: batWarnSlider.value
     property alias cfg_batteryCriticalThreshold: batCritSlider.value
+    property alias cfg_diskWarningThreshold: diskWarnSlider.value
+    property alias cfg_diskCriticalThreshold: diskCritSlider.value
     property alias cfg_diskTempWarningThreshold: diskTempWarnSlider.value
     property alias cfg_diskTempCriticalThreshold: diskTempCritSlider.value
 
@@ -552,6 +554,20 @@ KCM.SimpleKCM {
             }
             Rectangle { Layout.preferredWidth: 10; Layout.preferredHeight: 10; radius: 5; color: batWarnSlider.value <= batCritSlider.value ? cfg_criticalColor : "transparent" }
 
+            // --- Disk Usage ---
+            Label { text: i18n("Disk Usage") }
+            RowLayout {
+                Layout.fillWidth: true
+                Slider { id: diskWarnSlider; from: 10; to: 100; stepSize: 5; value: 80; Layout.fillWidth: true }
+                Label { text: Math.round(diskWarnSlider.value) + "%"; Layout.preferredWidth: 40 }
+            }
+            RowLayout {
+                Layout.fillWidth: true
+                Slider { id: diskCritSlider; from: 10; to: 100; stepSize: 5; value: 90; Layout.fillWidth: true }
+                Label { text: Math.round(diskCritSlider.value) + "%"; Layout.preferredWidth: 40 }
+            }
+            Rectangle { Layout.preferredWidth: 10; Layout.preferredHeight: 10; radius: 5; color: diskWarnSlider.value >= diskCritSlider.value ? cfg_criticalColor : "transparent" }
+
             // --- Disk Temperature ---
             Label { text: i18n("Disk Temp") }
             RowLayout {
@@ -607,6 +623,7 @@ KCM.SimpleKCM {
                 gpuWarnSlider.value = 70;  gpuCritSlider.value = 90
                 gpuTempWarnSlider.value = 60; gpuTempCritSlider.value = 85
                 batWarnSlider.value = 30;  batCritSlider.value = 15
+                diskWarnSlider.value = 80; diskCritSlider.value = 90
                 diskTempWarnSlider.value = 45; diskTempCritSlider.value = 60
             }
         }

--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -82,198 +82,14 @@ KCM.SimpleKCM {
     property string cfg_fanIcon:     "am-fan-symbolic"
     property string cfg_uptimeIcon:  "clock"
 
-    // ── Category metadata ──────────────────────────────────────────────────
-
-    readonly property var allKeys: ["cpu", "ram", "swap", "temp", "gpu", "bat", "net", "disk", "fan", "uptime"]
-
-    function resolveIcon(name) {
-        switch (name) {
-        case "am-cpu-symbolic":
-        case "nvidia-ram-symbolic":
-        case "am-disk-utility-symbolic":
-        case "am-fan-symbolic":
-        case "gpu-symbolic":
-            return Qt.resolvedUrl("../icons/" + name + ".svg");
-        default:
-            return name;
-        }
+    // Metric configuration adapter targeting KCM properties
+    MetricConfig {
+        id: metricConfig
+        target: metricsPage
+        propertyPrefix: "cfg_"
     }
 
-    function iconFor(key) {
-        var name;
-        switch (key) {
-            case "cpu":    name = cfg_cpuIcon; break;
-            case "ram":    name = cfg_ramIcon; break;
-            case "swap":   name = cfg_swapIcon; break;
-            case "temp":   name = cfg_tempIcon; break;
-            case "gpu":    name = cfg_gpuIcon; break;
-            case "bat":    name = cfg_batteryIcon; break;
-            case "net":    name = cfg_networkIcon; break;
-            case "disk":   name = cfg_diskIcon; break;
-            case "fan":    name = cfg_fanIcon; break;
-            case "uptime": name = cfg_uptimeIcon; break;
-            default: return "help-about";
-        }
-        return resolveIcon(name);
-    }
-
-    readonly property var metricMeta: ({
-        "cpu":  { label: i18n("CPU"),              subs: [
-            {key: "usage", label: i18n("Usage")},
-            {key: "freq",  label: i18n("Frequency")},
-            {key: "temp",  label: i18n("Temperature")}
-        ]},
-        "ram":  { label: i18n("RAM"),              subs: [
-            {key: "percentage", label: i18n("Percentage")},
-            {key: "used",       label: i18n("Used / Total")},
-            {key: "temp",       label: i18n("Temperature (DDR5)")}
-        ]},
-        "swap": { label: i18n("Swap"),             subs: [
-            {key: "percent", label: i18n("Usage (%)")},
-            {key: "used",    label: i18n("Used")},
-            {key: "free",    label: i18n("Free")},
-            {key: "total",   label: i18n("Total")}
-        ]},
-        "temp": { label: i18n("Temperature"),      subs: []},
-        "gpu":  { label: i18n("GPU"),              subs: [
-            {key: "usage", label: i18n("Usage")},
-            {key: "vram",  label: i18n("VRAM")},
-            {key: "temp",  label: i18n("Temperature")}
-        ]},
-        "bat":  { label: i18n("Battery"),          subs: [
-            {key: "percentage", label: i18n("Percentage")},
-            {key: "power",      label: i18n("Power consumption")}
-        ]},
-        "net":  { label: i18n("Network"),          subs: [
-            {key: "down", label: i18n("Download")},
-            {key: "up",   label: i18n("Upload")},
-            {key: "ip",   label: i18n("IP address")}
-        ]},
-        "disk": { label: i18n("Disk"),             subs: [
-            {key: "read",  label: i18n("Read")},
-            {key: "write", label: i18n("Write")},
-            {key: "temp",  label: i18n("Temperature")}
-        ]},
-        "fan":  { label: i18n("Fan"),              subs: []},
-        "uptime": { label: i18n("System Uptime"),  subs: []}
-    })
-
-    // ── Sub-metric helpers ─────────────────────────────────────────────────
-
-    function subMetrics(key) {
-        var str;
-        switch (key) {
-            case "cpu":  str = cfg_cpuSubMetrics;  break;
-            case "ram":  str = cfg_ramSubMetrics;  break;
-            case "swap": str = cfg_swapSubMetrics; break;
-            case "gpu":  str = cfg_gpuSubMetrics;  break;
-            case "bat":  str = cfg_batSubMetrics;  break;
-            case "net":  str = cfg_netSubMetrics;  break;
-            case "disk": str = cfg_diskSubMetrics; break;
-            default:     str = "";
-        }
-        return str ? str.split(",").filter(function(s){ return s.length > 0; }) : [];
-    }
-
-    function isEnabled(key) {
-        switch (key) {
-            case "cpu":    return cfg_cpuEnabled;
-            case "ram":    return cfg_ramEnabled;
-            case "swap":   return cfg_swapEnabled;
-            case "temp":   return cfg_tempEnabled;
-            case "gpu":    return cfg_gpuEnabled;
-            case "bat":    return cfg_batEnabled;
-            case "net":    return cfg_netEnabled;
-            case "disk":   return cfg_diskEnabled;
-            case "fan":    return cfg_fanEnabled;
-            case "uptime": return cfg_uptimeEnabled;
-        }
-        return false;
-    }
-
-    function setEnabled(key, val) {
-        switch (key) {
-            case "cpu":    cfg_cpuEnabled    = val; break;
-            case "ram":    cfg_ramEnabled    = val; break;
-            case "swap":   cfg_swapEnabled   = val; break;
-            case "temp":   cfg_tempEnabled   = val; break;
-            case "gpu":    cfg_gpuEnabled    = val; break;
-            case "bat":    cfg_batEnabled    = val; break;
-            case "net":    cfg_netEnabled    = val; break;
-            case "disk":   cfg_diskEnabled   = val; break;
-            case "fan":    cfg_fanEnabled    = val; break;
-            case "uptime": cfg_uptimeEnabled = val; break;
-        }
-    }
-
-    function visibilityFor(key) {
-        switch (key) {
-            case "cpu":    return cfg_cpuVisibility;
-            case "ram":    return cfg_ramVisibility;
-            case "swap":   return cfg_swapVisibility;
-            case "temp":   return cfg_tempVisibility;
-            case "gpu":    return cfg_gpuVisibility;
-            case "bat":    return cfg_batVisibility;
-            case "net":    return cfg_netVisibility;
-            case "disk":   return cfg_diskVisibility;
-            case "fan":    return cfg_fanVisibility;
-            case "uptime": return cfg_uptimeVisibility;
-        }
-        return "both";
-    }
-
-    function setVisibility(key, val) {
-        switch (key) {
-            case "cpu":    cfg_cpuVisibility    = val; break;
-            case "ram":    cfg_ramVisibility    = val; break;
-            case "swap":   cfg_swapVisibility   = val; break;
-            case "temp":   cfg_tempVisibility   = val; break;
-            case "gpu":    cfg_gpuVisibility    = val; break;
-            case "bat":    cfg_batVisibility    = val; break;
-            case "net":    cfg_netVisibility    = val; break;
-            case "disk":   cfg_diskVisibility   = val; break;
-            case "fan":    cfg_fanVisibility    = val; break;
-            case "uptime": cfg_uptimeVisibility = val; break;
-        }
-    }
-
-    function toggleSubMetric(key, sub, enable) {
-        var list = subMetrics(key);
-        if (enable) {
-            if (list.indexOf(sub) < 0) list.push(sub);
-        } else {
-            if (list.length <= 1) return;
-            list = list.filter(function(s){ return s !== sub; });
-        }
-        var canonical = metricMeta[key].subs.map(function(s){ return s.key; });
-        list.sort(function(a, b){ return canonical.indexOf(a) - canonical.indexOf(b); });
-        var str = list.join(",");
-        switch (key) {
-            case "cpu":  cfg_cpuSubMetrics  = str; break;
-            case "ram":  cfg_ramSubMetrics  = str; break;
-            case "swap": cfg_swapSubMetrics = str; break;
-            case "gpu":  cfg_gpuSubMetrics  = str; break;
-            case "bat":  cfg_batSubMetrics  = str; break;
-            case "net":  cfg_netSubMetrics  = str; break;
-            case "disk": cfg_diskSubMetrics = str; break;
-        }
-    }
-
-    // ── Ordering ───────────────────────────────────────────────────────────
-
-    readonly property var currentOrder: {
-        var keys = cfg_metricOrder.split(",").map(function(k){ return k.trim(); })
-            .filter(function(k){ return k.length > 0 && metricMeta[k] !== undefined; });
-        allKeys.forEach(function(k){ if (keys.indexOf(k) < 0) keys.push(k); });
-        return keys;
-    }
-
-    function moveMetric(fromIndex, toIndex) {
-        var keys = currentOrder.slice();
-        var item = keys.splice(fromIndex, 1)[0];
-        keys.splice(toIndex, 0, item);
-        cfg_metricOrder = keys.join(",");
-    }
+    readonly property var currentOrder: metricConfig.orderedKeys
 
     // Sensor discovery (GPU, Disk, Fan) via HardwareDiscovery
     HardwareDiscovery {
@@ -294,80 +110,6 @@ KCM.SimpleKCM {
         return found;
     }
 
-    // GPU label helpers
-    function parseGpuLabels(str) {
-        var result = {};
-        if (!str) return result;
-        str.split("|").forEach(function(pair) {
-            var sep = pair.indexOf(":");
-            if (sep > 0) result[pair.substring(0, sep)] = pair.substring(sep + 1);
-        });
-        return result;
-    }
-
-    function saveGpuLabel(gpuId, label) {
-        var labels = parseGpuLabels(cfg_gpuLabels);
-        var trimmed = (label || "").trim();
-        if (trimmed.length > 0) labels[gpuId] = trimmed;
-        else delete labels[gpuId];
-        var parts = [];
-        for (var id in labels) parts.push(id + ":" + labels[id]);
-        cfg_gpuLabels = parts.join("|");
-    }
-
-    // GPU sub-metric helpers
-    function parseGpuSubMetricsMap(str) {
-        var result = {};
-        if (!str) return result;
-        if (str.indexOf(":") >= 0) {
-            str.split("|").forEach(function(pair) {
-                var sep = pair.indexOf(":");
-                if (sep > 0) {
-                    var gid = pair.substring(0, sep);
-                    var subs = pair.substring(sep + 1).split(",").map(function(s){ return s.trim(); }).filter(function(s){ return s.length > 0; });
-                    result[gid] = subs;
-                }
-            });
-        }
-        return result;
-    }
-
-    function getGpuActiveSubMetrics(gpuId) {
-        var map = parseGpuSubMetricsMap(cfg_gpuSubMetrics);
-        if (map[gpuId] && map[gpuId].length > 0) {
-            return map[gpuId];
-        }
-        if (cfg_gpuSubMetrics && cfg_gpuSubMetrics.indexOf(":") < 0) {
-            return cfg_gpuSubMetrics.split(",").map(function(s){ return s.trim(); }).filter(function(s){ return s.length > 0; });
-        }
-        return MetricDefinitions.GROUPS.gpu.defaultSubMetrics.split(",").map(function(s){ return s.trim(); }).filter(function(s){ return s.length > 0; });
-    }
-
-    function toggleGpuSubMetric(gpuId, subKey, checked) {
-        var map = parseGpuSubMetricsMap(cfg_gpuSubMetrics);
-        for (var i = 0; i < discoveredGpus.length; i++) {
-            var gid = discoveredGpus[i].id;
-            if (!map[gid]) {
-                map[gid] = getGpuActiveSubMetrics(gid);
-            }
-        }
-        var subs = map[gpuId] ? map[gpuId].slice() : getGpuActiveSubMetrics(gpuId);
-        if (checked) {
-            if (subs.indexOf(subKey) < 0) subs.push(subKey);
-        } else {
-            if (subs.length > 1) {
-                subs = subs.filter(function(s){ return s !== subKey; });
-            }
-        }
-        map[gpuId] = subs;
-
-        var parts = [];
-        for (var id in map) {
-            parts.push(id + ":" + map[id].join(","));
-        }
-        cfg_gpuSubMetrics = parts.join("|");
-    }
-
     // Disk discovery
     readonly property var discoveredDisks: {
         var pattern = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.DISK_READ : /^disk\/(nvme\d+n\d+|sd[a-z]+)\/read$/;
@@ -382,27 +124,6 @@ KCM.SimpleKCM {
         return found;
     }
 
-    // Disk label helpers
-    function parseDiskLabels(str) {
-        var result = {};
-        if (!str) return result;
-        str.split("|").forEach(function(pair) {
-            var sep = pair.indexOf(":");
-            if (sep > 0) result[pair.substring(0, sep)] = pair.substring(sep + 1);
-        });
-        return result;
-    }
-
-    function saveDiskLabel(diskId, label) {
-        var labels = parseDiskLabels(cfg_diskLabels);
-        var trimmed = (label || "").trim();
-        if (trimmed.length > 0) labels[diskId] = trimmed;
-        else delete labels[diskId];
-        var parts = [];
-        for (var id in labels) parts.push(id + ":" + labels[id]);
-        cfg_diskLabels = parts.join("|");
-    }
-
     // Fan discovery
     readonly property var discoveredFans: {
         var pattern = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.FAN : /^(lmsensors|cpu|gpu)\/.*\/fan\d+$/i;
@@ -411,12 +132,7 @@ KCM.SimpleKCM {
         return ids.map(function(id, i) { return { id: id, name: "Fan " + (i + 1) }; });
     }
 
-    // --- Fan max-RPM capability check ---
-    // The "Max RPM for percentage" fallback is dead config when every
-    // discovered fan already reports its own max — only show it when at
-    // least one fan doesn't. Defaults to true (shown) until we've actually
-    // checked, so it doesn't appear to silently vanish for people who need it.
-
+    // Fan max-RPM capability check
     property bool fanMaxFallbackNeeded: true
 
     Sensors.SensorDataModel {
@@ -442,32 +158,7 @@ KCM.SimpleKCM {
         fanMaxFallbackNeeded = false;
     }
 
-    // --- Fan label helpers ---
-
-    function parseFanLabels(str) {
-        var result = Object.create(null);
-        if (!str) return result;
-        str.split("|").forEach(function(pair) {
-            var sep = pair.indexOf(":");
-            if (sep > 0) result[pair.substring(0, sep)] = pair.substring(sep + 1);
-        });
-        return result;
-    }
-
-    function saveFanLabel(fanId, label) {
-        var labels = parseFanLabels(cfg_fanLabels);
-        // "|" is the record separator in the stored string — strip it from
-        // user input so a label containing it can't corrupt the mapping
-        // (colons are fine: parseFanLabels only splits on the first one).
-        var trimmed = (label || "").replace(/\|/g, "").trim();
-        if (trimmed.length > 0) labels[fanId] = trimmed;
-        else delete labels[fanId];
-        var parts = [];
-        for (var id in labels) parts.push(id + ":" + labels[id]);
-        cfg_fanLabels = parts.join("|");
-    }
-
-    // --- Network interface discovery ---
+    // Network interface discovery
     property var ifaceList: ["auto"]
     Plasma5Support.DataSource {
         id: ifaceSource
@@ -484,9 +175,6 @@ KCM.SimpleKCM {
             metricsPage.ifaceList = ifaces;
         }
     }
-
-    // GPU sub-metric helpers (per-device, stored in gpuSubMetrics globally)
-    // gpuSubMetrics applies to all GPUs uniformly (simplification from per-GPU gpuMetrics)
 
     // UI
 
@@ -520,9 +208,9 @@ KCM.SimpleKCM {
                     Layout.fillWidth: true
 
                     readonly property string key: modelData
-                    readonly property var meta: metricsPage.metricMeta[key] || {}
-                    readonly property bool catEnabled: metricsPage.isEnabled(key)
-                    readonly property var activeSubs: metricsPage.subMetrics(key)
+                    readonly property var meta: MetricDefinitions.GROUPS[key] || {}
+                    readonly property bool catEnabled: metricConfig.isGroupEnabled(key)
+                    readonly property var activeSubs: metricConfig.getSubMetrics(key)
                     readonly property bool hasSubs: meta.subs && meta.subs.length > 0
 
                     // ── Category row ────────────────────────────────────────
@@ -531,7 +219,7 @@ KCM.SimpleKCM {
                         spacing: Kirigami.Units.smallSpacing
 
                         Kirigami.Icon {
-                            source: metricsPage.iconFor(catDelegate.key)
+                            source: metricConfig.getGroupIcon(catDelegate.key)
                             isMask: true
                             implicitWidth: Kirigami.Units.iconSizes.smallMedium
                             implicitHeight: Kirigami.Units.iconSizes.smallMedium
@@ -540,9 +228,9 @@ KCM.SimpleKCM {
 
                         CheckBox {
                             id: enabledCheck
-                            text: meta.label || key
+                            text: i18n(meta.name || meta.defaultLabel || key)
                             checked: catDelegate.catEnabled
-                            onToggled: metricsPage.setEnabled(key, checked)
+                            onToggled: metricConfig.setGroupEnabled(key, checked)
                             Layout.fillWidth: true
                         }
 
@@ -550,14 +238,14 @@ KCM.SimpleKCM {
                             id: visibilityCombo
                             model: [i18n("All"), i18n("Popup"), i18n("Compact")]
                             currentIndex: {
-                                var v = metricsPage.visibilityFor(catDelegate.key);
+                                var v = metricConfig.getVisibility(catDelegate.key);
                                 if (v === "widget") return 1;
                                 if (v === "compact") return 2;
                                 return 0;
                             }
                             onActivated: {
                                 var vals = ["both", "widget", "compact"];
-                                metricsPage.setVisibility(catDelegate.key, vals[index]);
+                                metricConfig.setVisibility(catDelegate.key, vals[index]);
                             }
                             implicitWidth: Kirigami.Units.gridUnit * 8
                             ToolTip.text: i18n("All=widget+compact, Popup=full view only, Compact=panel only")
@@ -573,7 +261,7 @@ KCM.SimpleKCM {
                             enabled: index > 0
                             implicitWidth: Kirigami.Units.gridUnit * 2
                             implicitHeight: Kirigami.Units.gridUnit * 2
-                            onClicked: metricsPage.moveMetric(index, index - 1)
+                            onClicked: metricConfig.moveMetric(index, index - 1)
                             ToolTip.text: i18n("Move up")
                             ToolTip.visible: hovered
                             ToolTip.delay: Kirigami.Units.toolTipDelay
@@ -584,7 +272,7 @@ KCM.SimpleKCM {
                             enabled: index < metricsPage.currentOrder.length - 1
                             implicitWidth: Kirigami.Units.gridUnit * 2
                             implicitHeight: Kirigami.Units.gridUnit * 2
-                            onClicked: metricsPage.moveMetric(index, index + 1)
+                            onClicked: metricConfig.moveMetric(index, index + 1)
                             ToolTip.text: i18n("Move down")
                             ToolTip.visible: hovered
                             ToolTip.delay: Kirigami.Units.toolTipDelay
@@ -592,8 +280,6 @@ KCM.SimpleKCM {
                     }
 
                     // ── Sub-metric toggles ─────────────────────────────────
-                    // Only shown for categories that have sub-metrics defined
-
                     Loader {
                         active: catDelegate.hasSubs && catDelegate.catEnabled
                         visible: active
@@ -614,27 +300,9 @@ KCM.SimpleKCM {
                                 Label { text: i18n("Label:"); opacity: 0.8 }
                                 TextField {
                                     implicitWidth: Kirigami.Units.gridUnit * 12
-                                    text: {
-                                        switch (catDelegate.key) {
-                                            case "cpu":  return cfg_cpuLabel;
-                                            case "ram":  return cfg_ramLabel;
-                                            case "swap": return cfg_swapLabel;
-                                            case "net":  return cfg_netLabel;
-                                            case "disk": return cfg_diskLabel;
-                                        }
-                                        return "";
-                                    }
-                                    placeholderText: catDelegate.meta.label
-                                    onTextEdited: {
-                                        var v = text.trim() || catDelegate.meta.label;
-                                        switch (catDelegate.key) {
-                                            case "cpu":  cfg_cpuLabel  = v; break;
-                                            case "ram":  cfg_ramLabel  = v; break;
-                                            case "swap": cfg_swapLabel = v; break;
-                                            case "net":  cfg_netLabel  = v; break;
-                                            case "disk": cfg_diskLabel = v; break;
-                                        }
-                                    }
+                                    text: metricConfig.getGroupLabel(catDelegate.key)
+                                    placeholderText: catDelegate.meta.defaultLabel || ""
+                                    onTextEdited: metricConfig.setGroupLabel(catDelegate.key, text.trim() || (catDelegate.meta.defaultLabel || ""))
                                 }
                             }
 
@@ -649,21 +317,16 @@ KCM.SimpleKCM {
 
                                     delegate: CheckBox {
                                         required property var modelData
-                                        text: modelData.label
+                                        text: i18n(modelData.label)
                                         checked: catDelegate.activeSubs.indexOf(modelData.key) >= 0
                                         enabled: {
-                                            // DDR5 temp: grey out when sensor not detected
-                                            // (can still uncheck, but not check)
                                             if (catDelegate.key === "ram" && modelData.key === "temp"
                                                 && !Plasmoid.configuration._ramTempDetected)
                                                 return checked;
                                             return !(checked && catDelegate.activeSubs.length <= 1);
                                         }
                                         onToggled: {
-                                            metricsPage.toggleSubMetric(catDelegate.key, modelData.key, checked);
-                                            // Manually touching Percentage/Used releases the
-                                            // popup-only "show both" override so the button
-                                            // can be used again.
+                                            metricConfig.toggleSubMetric(catDelegate.key, modelData.key, checked);
                                             if (catDelegate.key === "ram"
                                                 && (modelData.key === "percentage" || modelData.key === "used"))
                                                 cfg_ramWidgetShowBoth = false;
@@ -672,25 +335,18 @@ KCM.SimpleKCM {
                                 }
                             }
 
-                            // RAM: popup-only override to show both Percentage and Used/Total
-                            // in the widget window without changing which one is checked here
-                            // (that choice still governs the compact panel on its own).
+                            // RAM popup override button
                             Button {
                                 visible: catDelegate.key === "ram"
                                 text: i18n("Show both in popup window")
                                 checkable: true
                                 checked: cfg_ramWidgetShowBoth
-                                // Greyed out only when both are already individually
-                                // selected — togglable if just % , just Used/Total, or neither.
                                 enabled: !(catDelegate.activeSubs.indexOf("percentage") >= 0
                                     && catDelegate.activeSubs.indexOf("used") >= 0)
                                 onToggled: cfg_ramWidgetShowBoth = checked
                             }
 
-                            // DDR5 temperature hint — only relevant once the user has
-                            // enabled the sub-metric and the sensor genuinely isn't there;
-                            // it used to show whenever the checkbox was checked, which was
-                            // confusing on hardware where the sensor IS detected and working.
+                            // DDR5 temperature hint
                             Label {
                                 visible: catDelegate.key === "ram" && catDelegate.activeSubs.indexOf("temp") >= 0
                                     && !Plasmoid.configuration._ramTempDetected
@@ -700,8 +356,6 @@ KCM.SimpleKCM {
                                 wrapMode: Text.WordWrap
                                 Layout.maximumWidth: Kirigami.Units.gridUnit * 24
                             }
-
-                            // ── Category-specific inline settings ──────────
 
                             // Network: interface selector
                             RowLayout {
@@ -726,7 +380,7 @@ KCM.SimpleKCM {
                                 }
                             }
 
-                            // GPU: per-device selection
+                            // GPU: per-device selection and sub-metrics
                             ColumnLayout {
                                 visible: catDelegate.key === "gpu"
                                 spacing: Kirigami.Units.smallSpacing
@@ -758,34 +412,14 @@ KCM.SimpleKCM {
                                         Layout.fillWidth: true
                                         Layout.leftMargin: Kirigami.Units.smallSpacing
 
-                                        property bool _gpuEnabled: {
-                                            if (!cfg_gpuSelection || cfg_gpuSelection === "") return true;
-                                            if (cfg_gpuSelection === "none") return false;
-                                            return cfg_gpuSelection.split(",").indexOf(modelData.id) >= 0;
-                                        }
+                                        property bool _gpuEnabled: metricConfig.isGpuSelected(modelData.id)
 
                                         CheckBox {
                                             text: gpuDelegate.modelData.name
                                             checked: gpuDelegate._gpuEnabled
                                             onToggled: {
-                                                var ids;
-                                                if (!cfg_gpuSelection || cfg_gpuSelection === "") {
-                                                    ids = gpuSelectorRepeater.model.map(function(g){ return g.id; });
-                                                } else if (cfg_gpuSelection === "none") {
-                                                    ids = [];
-                                                } else {
-                                                    ids = cfg_gpuSelection.split(",").filter(function(s){ return s.length > 0; });
-                                                }
-                                                if (checked) {
-                                                    if (ids.indexOf(modelData.id) < 0) ids.push(modelData.id);
-                                                } else {
-                                                    ids = ids.filter(function(id){ return id !== modelData.id; });
-                                                }
                                                 var allIds = gpuSelectorRepeater.model.map(function(g){ return g.id; });
-                                                var allSelected = allIds.every(function(id){ return ids.indexOf(id) >= 0; });
-                                                if (allSelected)           cfg_gpuSelection = "";
-                                                else if (ids.length === 0) cfg_gpuSelection = "none";
-                                                else                       cfg_gpuSelection = ids.join(",");
+                                                metricConfig.setGpuSelected(modelData.id, checked, allIds);
                                             }
                                         }
 
@@ -800,9 +434,9 @@ KCM.SimpleKCM {
                                                 Label { text: i18n("Label:"); opacity: 0.8 }
                                                 TextField {
                                                     implicitWidth: Kirigami.Units.gridUnit * 12
-                                                    text: metricsPage.parseGpuLabels(cfg_gpuLabels)[gpuDelegate.modelData.id] || ""
+                                                    text: metricConfig.parseGpuLabels()[gpuDelegate.modelData.id] || ""
                                                     placeholderText: gpuDelegate.modelData.name
-                                                    onTextEdited: metricsPage.saveGpuLabel(gpuDelegate.modelData.id, text)
+                                                    onTextEdited: metricConfig.saveGpuLabel(gpuDelegate.modelData.id, text)
                                                 }
                                             }
 
@@ -811,27 +445,21 @@ KCM.SimpleKCM {
                                                 spacing: Kirigami.Units.largeSpacing
                                                 Layout.fillWidth: true
 
-                                                property var activeGpuSubs: metricsPage.getGpuActiveSubMetrics(gpuDelegate.modelData.id)
+                                                property var activeGpuSubs: metricConfig.getGpuSubMetrics(gpuDelegate.modelData.id)
 
-                                                CheckBox {
-                                                    text: i18n("Usage")
-                                                    checked: parent.activeGpuSubs.indexOf("usage") >= 0
-                                                    enabled: !(checked && parent.activeGpuSubs.length <= 1)
-                                                    onToggled: metricsPage.toggleGpuSubMetric(gpuDelegate.modelData.id, "usage", checked)
-                                                }
+                                                Repeater {
+                                                    model: catDelegate.meta.subs
 
-                                                CheckBox {
-                                                    text: i18n("VRAM")
-                                                    checked: parent.activeGpuSubs.indexOf("vram") >= 0
-                                                    enabled: !(checked && parent.activeGpuSubs.length <= 1)
-                                                    onToggled: metricsPage.toggleGpuSubMetric(gpuDelegate.modelData.id, "vram", checked)
-                                                }
-
-                                                CheckBox {
-                                                    text: i18n("Temperature")
-                                                    checked: parent.activeGpuSubs.indexOf("temp") >= 0
-                                                    enabled: !(checked && parent.activeGpuSubs.length <= 1)
-                                                    onToggled: metricsPage.toggleGpuSubMetric(gpuDelegate.modelData.id, "temp", checked)
+                                                    delegate: CheckBox {
+                                                        required property var modelData
+                                                        text: i18n(modelData.label)
+                                                        checked: parent.activeGpuSubs.indexOf(modelData.key) >= 0
+                                                        enabled: !(checked && parent.activeGpuSubs.length <= 1)
+                                                        onToggled: {
+                                                            var allIds = metricsPage.discoveredGpus.map(function(g){ return g.id; });
+                                                            metricConfig.toggleGpuSubMetric(gpuDelegate.modelData.id, modelData.key, checked, allIds);
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }
@@ -877,9 +505,9 @@ KCM.SimpleKCM {
                                         }
                                         TextField {
                                             implicitWidth: Kirigami.Units.gridUnit * 12
-                                            text: metricsPage.parseDiskLabels(cfg_diskLabels)[modelData.id] || ""
+                                            text: metricConfig.parseDiskLabels()[modelData.id] || ""
                                             placeholderText: modelData.name
-                                            onTextEdited: metricsPage.saveDiskLabel(modelData.id, text)
+                                            onTextEdited: metricConfig.saveDiskLabel(modelData.id, text)
                                         }
                                     }
                                 }
@@ -887,8 +515,7 @@ KCM.SimpleKCM {
                         }
                     }
 
-                    // ── Single-metric label fields (temp, fan, uptime) ─────
-
+                    // Single-metric label fields (temp, fan, uptime)
                     Loader {
                         active: catDelegate.key === "temp" && catDelegate.catEnabled
                         visible: active
@@ -905,13 +532,12 @@ KCM.SimpleKCM {
                                 Label { text: i18n("Label:"); opacity: 0.8 }
                                 TextField {
                                     implicitWidth: Kirigami.Units.gridUnit * 12
-                                    text: cfg_tempLabel
+                                    text: metricConfig.getGroupLabel("temp")
                                     placeholderText: i18n("System")
-                                    onTextEdited: cfg_tempLabel = text.trim() || "System"
+                                    onTextEdited: metricConfig.setGroupLabel("temp", text.trim() || "System")
                                 }
                             }
 
-                            // Fallback hint — shown when runtime detects no chipset sensor
                             Label {
                                 visible: Plasmoid.configuration._tempFallbackActive
                                 text: i18n("No chipset temp sensor detected, fallback to CPU temp sensor")
@@ -940,13 +566,12 @@ KCM.SimpleKCM {
                                 Label { text: i18n("Label:"); opacity: 0.8 }
                                 TextField {
                                     implicitWidth: Kirigami.Units.gridUnit * 12
-                                    text: cfg_fanLabel
+                                    text: metricConfig.getGroupLabel("fan")
                                     placeholderText: i18n("FAN")
-                                    onTextEdited: cfg_fanLabel = text.trim() || "FAN"
+                                    onTextEdited: metricConfig.setGroupLabel("fan", text.trim() || "FAN")
                                 }
                             }
 
-                            // Per-fan naming
                             ColumnLayout {
                                 spacing: Kirigami.Units.smallSpacing
                                 Layout.fillWidth: true
@@ -967,9 +592,9 @@ KCM.SimpleKCM {
                                         }
                                         TextField {
                                             implicitWidth: Kirigami.Units.gridUnit * 12
-                                            text: metricsPage.parseFanLabels(cfg_fanLabels)[modelData.id] || ""
+                                            text: metricConfig.parseFanLabels()[modelData.id] || ""
                                             placeholderText: modelData.name
-                                            onTextEdited: metricsPage.saveFanLabel(modelData.id, text)
+                                            onTextEdited: metricConfig.saveFanLabel(modelData.id, text)
                                         }
                                     }
                                 }
@@ -999,7 +624,8 @@ KCM.SimpleKCM {
                             }
                         }
                     }
-                    // ── Divider ────────────────────────────────────────────
+
+                    // Divider
                     Rectangle {
                         visible: index < metricsPage.currentOrder.length - 1
                         Layout.fillWidth: true

--- a/contents/ui/models/MetricConfig.qml
+++ b/contents/ui/models/MetricConfig.qml
@@ -273,19 +273,25 @@ QtObject {
     readonly property int gpuTempCriticalThreshold: (target && target[propertyPrefix + "gpuTempCriticalThreshold"]) || 85
     readonly property int batteryWarningThreshold:  (target && target[propertyPrefix + "batteryWarningThreshold"])  || 30
     readonly property int batteryCriticalThreshold: (target && target[propertyPrefix + "batteryCriticalThreshold"]) || 15
+    readonly property int diskWarningThreshold:     (target && target[propertyPrefix + "diskWarningThreshold"])     || 80
+    readonly property int diskCriticalThreshold:    (target && target[propertyPrefix + "diskCriticalThreshold"])    || 90
     readonly property int diskTempWarningThreshold: (target && target[propertyPrefix + "diskTempWarningThreshold"]) || 45
     readonly property int diskTempCriticalThreshold: (target && target[propertyPrefix + "diskTempCriticalThreshold"]) || 60
 
     function getWarningThreshold(key) {
         var prop = propertyPrefix + key + "WarningThreshold";
         var val = target ? target[prop] : undefined;
-        return val !== undefined ? val : 70;
+        if (val !== undefined) return val;
+        var direct = root[key + "WarningThreshold"];
+        return direct !== undefined ? direct : 70;
     }
 
     function getCriticalThreshold(key) {
         var prop = propertyPrefix + key + "CriticalThreshold";
         var val = target ? target[prop] : undefined;
-        return val !== undefined ? val : 90;
+        if (val !== undefined) return val;
+        var direct = root[key + "CriticalThreshold"];
+        return direct !== undefined ? direct : 90;
     }
 
     // Units & hardware preferences

--- a/contents/ui/models/MetricConfig.qml
+++ b/contents/ui/models/MetricConfig.qml
@@ -1,19 +1,12 @@
-// MetricConfig is the single-source adapter between Plasmoid.configuration and
-// the rest of the widget. Every sensor module and MetricStore read from here
-// rather than touching Plasmoid.configuration directly.
-//
-// It owns:
-//   - group enable flags and isGroupEnabled()
-//   - sub-metric and visibility settings per group
-//   - labels, icons, and threshold values (with defaults)
-//   - isMetricVisible() which combines all three visibility axes
-//   - orderedKeys: the canonical metric display order
 import QtQuick
 import org.kde.plasma.plasmoid
 import "./MetricDefinitions.js" as Defs
 
 QtObject {
     id: root
+
+    property var target: Plasmoid.configuration
+    property string propertyPrefix: ""
 
     // Icon fallback resolver
     function resolveIcon(name) {
@@ -29,90 +22,122 @@ QtObject {
         }
     }
 
-    // Whether each group appears in the widget at all. Disabled groups are
-    // skipped by MetricStore and hidden from the config metrics page.
-    readonly property bool cpuEnabled:    Plasmoid.configuration.cpuEnabled
-    readonly property bool ramEnabled:    Plasmoid.configuration.ramEnabled
-    readonly property bool swapEnabled:   Plasmoid.configuration.swapEnabled
-    readonly property bool tempEnabled:   Plasmoid.configuration.tempEnabled
-    readonly property bool gpuEnabled:    Plasmoid.configuration.gpuEnabled
-    readonly property bool batEnabled:    Plasmoid.configuration.batEnabled
-    readonly property bool netEnabled:    Plasmoid.configuration.netEnabled
-    readonly property bool diskEnabled:   Plasmoid.configuration.diskEnabled
-    readonly property bool fanEnabled:    Plasmoid.configuration.fanEnabled
-    readonly property bool uptimeEnabled: Plasmoid.configuration.uptimeEnabled
+    // Group enable flags
+    readonly property bool cpuEnabled:    (target && target[propertyPrefix + "cpuEnabled"] !== undefined)    ? Boolean(target[propertyPrefix + "cpuEnabled"])    : false
+    readonly property bool ramEnabled:    (target && target[propertyPrefix + "ramEnabled"] !== undefined)    ? Boolean(target[propertyPrefix + "ramEnabled"])    : false
+    readonly property bool swapEnabled:   (target && target[propertyPrefix + "swapEnabled"] !== undefined)   ? Boolean(target[propertyPrefix + "swapEnabled"])   : false
+    readonly property bool tempEnabled:   (target && target[propertyPrefix + "tempEnabled"] !== undefined)   ? Boolean(target[propertyPrefix + "tempEnabled"])   : false
+    readonly property bool gpuEnabled:    (target && target[propertyPrefix + "gpuEnabled"] !== undefined)    ? Boolean(target[propertyPrefix + "gpuEnabled"])    : false
+    readonly property bool batEnabled:    (target && target[propertyPrefix + "batEnabled"] !== undefined)    ? Boolean(target[propertyPrefix + "batEnabled"])    : false
+    readonly property bool netEnabled:    (target && target[propertyPrefix + "netEnabled"] !== undefined)    ? Boolean(target[propertyPrefix + "netEnabled"])    : false
+    readonly property bool diskEnabled:   (target && target[propertyPrefix + "diskEnabled"] !== undefined)   ? Boolean(target[propertyPrefix + "diskEnabled"])   : false
+    readonly property bool fanEnabled:    (target && target[propertyPrefix + "fanEnabled"] !== undefined)    ? Boolean(target[propertyPrefix + "fanEnabled"])    : false
+    readonly property bool uptimeEnabled: (target && target[propertyPrefix + "uptimeEnabled"] !== undefined) ? Boolean(target[propertyPrefix + "uptimeEnabled"]) : false
+
+    readonly property var _enabledMap: ({
+        cpu: cpuEnabled, ram: ramEnabled, swap: swapEnabled, temp: tempEnabled,
+        gpu: gpuEnabled, bat: batEnabled, net: netEnabled, disk: diskEnabled,
+        fan: fanEnabled, uptime: uptimeEnabled
+    })
 
     function isGroupEnabled(group) {
-        switch (group) {
-        case "cpu":    return cpuEnabled;
-        case "ram":    return ramEnabled;
-        case "swap":   return swapEnabled;
-        case "temp":   return tempEnabled;
-        case "gpu":    return gpuEnabled;
-        case "bat":    return batEnabled;
-        case "net":    return netEnabled;
-        case "disk":   return diskEnabled;
-        case "fan":    return fanEnabled;
-        case "uptime": return uptimeEnabled;
-        default:       return false;
+        return _enabledMap[group] !== undefined ? _enabledMap[group] : false;
+    }
+
+    function setGroupEnabled(group, val) {
+        var prop = propertyPrefix + group + "Enabled";
+        if (target && target[prop] !== undefined) {
+            target[prop] = Boolean(val);
         }
     }
 
-    // Sub-metric comma-separated lists
-    readonly property string cpuSubMetrics:  Plasmoid.configuration.cpuSubMetrics  || Defs.GROUPS.cpu.defaultSubMetrics
-    readonly property string ramSubMetrics:  Plasmoid.configuration.ramSubMetrics  || Defs.GROUPS.ram.defaultSubMetrics
-    readonly property string swapSubMetrics: Plasmoid.configuration.swapSubMetrics || Defs.GROUPS.swap.defaultSubMetrics
-    readonly property string gpuSubMetrics:  Plasmoid.configuration.gpuSubMetrics  || Defs.GROUPS.gpu.defaultSubMetrics
-    readonly property string batSubMetrics:  Plasmoid.configuration.batSubMetrics  || Defs.GROUPS.bat.defaultSubMetrics
-    readonly property string netSubMetrics:  Plasmoid.configuration.netSubMetrics  || Defs.GROUPS.net.defaultSubMetrics
-    readonly property string diskSubMetrics: Plasmoid.configuration.diskSubMetrics || Defs.GROUPS.disk.defaultSubMetrics
+    // Sub-metric settings
+    readonly property string cpuSubMetrics:  (target && target[propertyPrefix + "cpuSubMetrics"])  || Defs.GROUPS.cpu.defaultSubMetrics
+    readonly property string ramSubMetrics:  (target && target[propertyPrefix + "ramSubMetrics"])  || Defs.GROUPS.ram.defaultSubMetrics
+    readonly property string swapSubMetrics: (target && target[propertyPrefix + "swapSubMetrics"]) || Defs.GROUPS.swap.defaultSubMetrics
+    readonly property string gpuSubMetrics:  (target && target[propertyPrefix + "gpuSubMetrics"])  || Defs.GROUPS.gpu.defaultSubMetrics
+    readonly property string batSubMetrics:  (target && target[propertyPrefix + "batSubMetrics"])  || Defs.GROUPS.bat.defaultSubMetrics
+    readonly property string netSubMetrics:  (target && target[propertyPrefix + "netSubMetrics"])  || Defs.GROUPS.net.defaultSubMetrics
+    readonly property string diskSubMetrics: (target && target[propertyPrefix + "diskSubMetrics"]) || Defs.GROUPS.disk.defaultSubMetrics
 
-    // Where each group appears: "compact" (panel only), "widget" (popup only),
-    // or "both". isMetricVisible() enforces this per sub-metric.
-    readonly property string cpuVisibility:    Plasmoid.configuration.cpuVisibility    || "both"
-    readonly property string ramVisibility:    Plasmoid.configuration.ramVisibility    || "both"
-    readonly property string swapVisibility:   Plasmoid.configuration.swapVisibility   || "both"
-    readonly property string tempVisibility:   Plasmoid.configuration.tempVisibility   || "both"
-    readonly property string gpuVisibility:    Plasmoid.configuration.gpuVisibility    || "both"
-    readonly property string batVisibility:    Plasmoid.configuration.batVisibility    || "both"
-    readonly property string netVisibility:    Plasmoid.configuration.netVisibility    || "both"
-    readonly property string diskVisibility:   Plasmoid.configuration.diskVisibility   || "both"
-    readonly property string fanVisibility:    Plasmoid.configuration.fanVisibility    || "both"
-    readonly property string uptimeVisibility: Plasmoid.configuration.uptimeVisibility || "both"
+    readonly property var _subMetricsMap: ({
+        cpu: cpuSubMetrics, ram: ramSubMetrics, swap: swapSubMetrics, gpu: gpuSubMetrics,
+        bat: batSubMetrics, net: netSubMetrics, disk: diskSubMetrics
+    })
+
+    function getSubMetricsString(key) {
+        if (_subMetricsMap[key] !== undefined) return _subMetricsMap[key];
+        var grp = Defs.GROUPS[key];
+        return grp ? (grp.defaultSubMetrics || "") : "";
+    }
+
+    function getSubMetrics(key) {
+        var str = getSubMetricsString(key);
+        if (!str) return [];
+        return str.split(",").map(function(s){ return s.trim(); }).filter(function(s){ return s.length > 0; });
+    }
+
+    function setSubMetrics(key, values) {
+        var str = Array.isArray(values) ? values.join(",") : String(values || "");
+        var prop = propertyPrefix + key + "SubMetrics";
+        if (target && target[prop] !== undefined) {
+            target[prop] = str;
+        }
+    }
+
+    function toggleSubMetric(key, subKey, enable) {
+        var list = getSubMetrics(key);
+        if (enable) {
+            if (list.indexOf(subKey) < 0) list.push(subKey);
+        } else {
+            if (list.length <= 1) return;
+            list = list.filter(function(s){ return s !== subKey; });
+        }
+        var grp = Defs.GROUPS[key];
+        if (grp && grp.subs) {
+            var canonical = grp.subs.map(function(s){ return s.key; });
+            list.sort(function(a, b){ return canonical.indexOf(a) - canonical.indexOf(b); });
+        }
+        setSubMetrics(key, list);
+    }
+
+    // Visibility settings
+    readonly property string cpuVisibility:    (target && target[propertyPrefix + "cpuVisibility"])    || "both"
+    readonly property string ramVisibility:    (target && target[propertyPrefix + "ramVisibility"])    || "both"
+    readonly property string swapVisibility:   (target && target[propertyPrefix + "swapVisibility"])   || "both"
+    readonly property string tempVisibility:   (target && target[propertyPrefix + "tempVisibility"])   || "both"
+    readonly property string gpuVisibility:    (target && target[propertyPrefix + "gpuVisibility"])    || "both"
+    readonly property string batVisibility:    (target && target[propertyPrefix + "batVisibility"])    || "both"
+    readonly property string netVisibility:    (target && target[propertyPrefix + "netVisibility"])    || "both"
+    readonly property string diskVisibility:   (target && target[propertyPrefix + "diskVisibility"])   || "both"
+    readonly property string fanVisibility:    (target && target[propertyPrefix + "fanVisibility"])    || "both"
+    readonly property string uptimeVisibility: (target && target[propertyPrefix + "uptimeVisibility"]) || "both"
+
+    readonly property var _visibilityMap: ({
+        cpu: cpuVisibility, ram: ramVisibility, swap: swapVisibility, temp: tempVisibility,
+        gpu: gpuVisibility, bat: batVisibility, net: netVisibility, disk: diskVisibility,
+        fan: fanVisibility, uptime: uptimeVisibility
+    })
+
+    function getVisibility(group) {
+        return _visibilityMap[group] || "both";
+    }
 
     function getGroupVisibility(group) {
-        switch (group) {
-        case "cpu":    return cpuVisibility;
-        case "ram":    return ramVisibility;
-        case "swap":   return swapVisibility;
-        case "temp":   return tempVisibility;
-        case "gpu":    return gpuVisibility;
-        case "bat":    return batVisibility;
-        case "net":    return netVisibility;
-        case "disk":   return diskVisibility;
-        case "fan":    return fanVisibility;
-        case "uptime": return uptimeVisibility;
-        default:       return "both";
+        return getVisibility(group);
+    }
+
+    function setVisibility(group, val) {
+        var prop = propertyPrefix + group + "Visibility";
+        if (target && target[prop] !== undefined) {
+            target[prop] = val;
         }
     }
 
     function isSubMetricEnabled(group, subKey, deviceId) {
-        var str = "";
-        switch (group) {
-        case "cpu":  str = cpuSubMetrics; break;
-        case "ram":  str = ramSubMetrics; break;
-        case "swap": str = swapSubMetrics; break;
-        case "gpu":  str = gpuSubMetrics; break;
-        case "bat":  str = batSubMetrics; break;
-        case "net":  str = netSubMetrics; break;
-        case "disk": str = diskSubMetrics; break;
-        case "temp": return true;
-        case "fan": return true;
-        case "uptime": return true;
-        default: return true;
-        }
+        var str = getSubMetricsString(group);
+        if (!str) return true;
 
-        // Per-device sub-metric support
         if (str.indexOf(":") >= 0) {
             if (deviceId) {
                 var pairs = str.split("|");
@@ -136,8 +161,6 @@ QtObject {
         return str.split(",").map(function(s){ return s.trim(); }).indexOf(subKey) >= 0;
     }
 
-    // Returns true when a metric should appear in the given view ("compact" or "widget").
-    // Checks group enable, group visibility target, and sub-metric enable in that order.
     function isMetricVisible(group, subKey, view, deviceId) {
         if (!isGroupEnabled(group)) return false;
         var vis = getGroupVisibility(group);
@@ -151,117 +174,134 @@ QtObject {
     }
 
     // Labels
-    readonly property string cpuLabel:  Plasmoid.configuration.cpuLabel  || "CPU"
-    readonly property string ramLabel:  Plasmoid.configuration.ramLabel  || "RAM"
-    readonly property string swapLabel: Plasmoid.configuration.swapLabel || "SWAP"
-    readonly property string tempLabel: Plasmoid.configuration.tempLabel || "System"
-    readonly property string netLabel:  Plasmoid.configuration.netLabel  || "NET"
-    readonly property string diskLabel: Plasmoid.configuration.diskLabel || "DSK"
-    readonly property string fanLabel:  Plasmoid.configuration.fanLabel  || "FAN"
-    readonly property string gpuLabels: Plasmoid.configuration.gpuLabels || ""
-    readonly property string diskLabels: Plasmoid.configuration.diskLabels || ""
-    readonly property string fanLabels: Plasmoid.configuration.fanLabels || ""
+    readonly property string cpuLabel:   (target && target[propertyPrefix + "cpuLabel"])   || "CPU"
+    readonly property string ramLabel:   (target && target[propertyPrefix + "ramLabel"])   || "RAM"
+    readonly property string swapLabel:  (target && target[propertyPrefix + "swapLabel"])  || "SWAP"
+    readonly property string tempLabel:  (target && target[propertyPrefix + "tempLabel"])  || "System"
+    readonly property string netLabel:   (target && target[propertyPrefix + "netLabel"])   || "NET"
+    readonly property string diskLabel:  (target && target[propertyPrefix + "diskLabel"])  || "DSK"
+    readonly property string fanLabel:   (target && target[propertyPrefix + "fanLabel"])   || "FAN"
+    readonly property string gpuLabels:  (target && target[propertyPrefix + "gpuLabels"])  || ""
+    readonly property string diskLabels: (target && target[propertyPrefix + "diskLabels"]) || ""
+    readonly property string fanLabels:  (target && target[propertyPrefix + "fanLabels"])  || ""
+
+    readonly property var _labelMap: ({
+        cpu: cpuLabel, ram: ramLabel, swap: swapLabel, temp: tempLabel,
+        net: netLabel, disk: diskLabel, fan: fanLabel
+    })
 
     function getGroupLabel(group) {
-        switch (group) {
-        case "cpu":    return cpuLabel;
-        case "ram":    return ramLabel;
-        case "swap":   return swapLabel;
-        case "temp":   return tempLabel;
-        case "gpu":    return "GPU";
-        case "bat":    return "BAT";
-        case "net":    return netLabel;
-        case "disk":   return diskLabel;
-        case "fan":    return fanLabel;
-        case "uptime": return "UPTIME";
-        default:       return group.toUpperCase();
+        if (_labelMap[group] !== undefined) return _labelMap[group];
+        var grp = Defs.GROUPS[group];
+        return grp ? grp.defaultLabel : group.toUpperCase();
+    }
+
+    function setGroupLabel(group, val) {
+        var prop = propertyPrefix + group + "Label";
+        if (target && target[prop] !== undefined) {
+            target[prop] = val;
         }
     }
 
     // Icons
-    readonly property string cpuIcon:     resolveIcon(Plasmoid.configuration.cpuIcon || "am-cpu-symbolic")
-    readonly property string ramIcon:     resolveIcon(Plasmoid.configuration.ramIcon || "nvidia-ram-symbolic")
-    readonly property string swapIcon:    resolveIcon(Plasmoid.configuration.swapIcon || "nvidia-ram-symbolic")
-    readonly property string tempIcon:    resolveIcon(Plasmoid.configuration.tempIcon || "temperature-normal")
-    readonly property string gpuIcon:     resolveIcon(Plasmoid.configuration.gpuIcon || "gpu-symbolic")
-    readonly property string batteryIcon: resolveIcon(Plasmoid.configuration.batteryIcon || "battery-good")
-    readonly property string powerIcon:   resolveIcon(Plasmoid.configuration.powerIcon || "battery-charging-60")
-    readonly property string networkIcon: resolveIcon(Plasmoid.configuration.networkIcon || "network-wireless")
-    readonly property string diskIcon:    resolveIcon(Plasmoid.configuration.diskIcon || "am-disk-utility-symbolic")
-    readonly property string fanIcon:     resolveIcon(Plasmoid.configuration.fanIcon || "am-fan-symbolic")
-    readonly property string uptimeIcon:  resolveIcon(Plasmoid.configuration.uptimeIcon || "clock")
+    readonly property string cpuIcon:     resolveIcon((target && target[propertyPrefix + "cpuIcon"])     || "am-cpu-symbolic")
+    readonly property string ramIcon:     resolveIcon((target && target[propertyPrefix + "ramIcon"])     || "nvidia-ram-symbolic")
+    readonly property string swapIcon:    resolveIcon((target && target[propertyPrefix + "swapIcon"])    || "nvidia-ram-symbolic")
+    readonly property string tempIcon:    resolveIcon((target && target[propertyPrefix + "tempIcon"])    || "temperature-normal")
+    readonly property string gpuIcon:     resolveIcon((target && target[propertyPrefix + "gpuIcon"])     || "gpu-symbolic")
+    readonly property string batteryIcon: resolveIcon((target && target[propertyPrefix + "batteryIcon"]) || "battery-good")
+    readonly property string powerIcon:   resolveIcon((target && target[propertyPrefix + "powerIcon"])   || "battery-charging-60")
+    readonly property string networkIcon: resolveIcon((target && target[propertyPrefix + "networkIcon"]) || "network-wireless")
+    readonly property string diskIcon:    resolveIcon((target && target[propertyPrefix + "diskIcon"])    || "am-disk-utility-symbolic")
+    readonly property string fanIcon:     resolveIcon((target && target[propertyPrefix + "fanIcon"])     || "am-fan-symbolic")
+    readonly property string uptimeIcon:  resolveIcon((target && target[propertyPrefix + "uptimeIcon"])  || "clock")
+
+    readonly property var _iconMap: ({
+        cpu: cpuIcon, ram: ramIcon, swap: swapIcon, temp: tempIcon, gpu: gpuIcon,
+        bat: batteryIcon, net: networkIcon, disk: diskIcon, fan: fanIcon, uptime: uptimeIcon
+    })
 
     function getGroupIcon(group) {
-        switch (group) {
-        case "cpu":    return cpuIcon;
-        case "ram":    return ramIcon;
-        case "swap":   return swapIcon;
-        case "temp":   return tempIcon;
-        case "gpu":    return gpuIcon;
-        case "bat":    return batteryIcon;
-        case "net":    return networkIcon;
-        case "disk":   return diskIcon;
-        case "fan":    return fanIcon;
-        case "uptime": return uptimeIcon;
-        default:       return "";
-        }
+        return _iconMap[group] || "";
     }
 
-    // Threshold colors. getWarningThreshold / getCriticalThreshold look up the
-    // property by name (e.g. "cpu" -> cpuWarningThreshold) so new groups only
-    // need new properties here, not changes to those functions.
-    readonly property bool enableThresholdColors: Plasmoid.configuration.enableThresholdColors
-    readonly property string warningColor:        Plasmoid.configuration.warningColor  || "#e5a50a"
-    readonly property string criticalColor:       Plasmoid.configuration.criticalColor || "#da4453"
+    // Generic group descriptor
+    function getGroup(key) {
+        var grp = Defs.GROUPS[key] || {};
+        return {
+            id: key,
+            name: grp.name || grp.defaultLabel || key,
+            defaultLabel: grp.defaultLabel || key.toUpperCase(),
+            label: getGroupLabel(key),
+            icon: getGroupIcon(key),
+            enabled: isGroupEnabled(key),
+            visibility: getVisibility(key),
+            subMetrics: getSubMetrics(key),
+            subs: grp.subs || [],
+            hasSubs: Boolean(grp.subs && grp.subs.length > 0)
+        };
+    }
 
-    readonly property int cpuWarningThreshold:      Plasmoid.configuration.cpuWarningThreshold      || 70
-    readonly property int cpuCriticalThreshold:     Plasmoid.configuration.cpuCriticalThreshold     || 90
-    readonly property int tempWarningThreshold:     Plasmoid.configuration.tempWarningThreshold     || 60
-    readonly property int tempCriticalThreshold:    Plasmoid.configuration.tempCriticalThreshold    || 85
-    readonly property int systemWarningThreshold:   Plasmoid.configuration.systemWarningThreshold   || 60
-    readonly property int systemCriticalThreshold:  Plasmoid.configuration.systemCriticalThreshold  || 85
-    readonly property int ramWarningThreshold:      Plasmoid.configuration.ramWarningThreshold      || 70
-    readonly property int ramCriticalThreshold:     Plasmoid.configuration.ramCriticalThreshold     || 90
-    readonly property int swapWarningThreshold:     Plasmoid.configuration.swapWarningThreshold     || 70
-    readonly property int swapCriticalThreshold:    Plasmoid.configuration.swapCriticalThreshold    || 90
-    readonly property int ramTempWarningThreshold:  Plasmoid.configuration.ramTempWarningThreshold  || 60
-    readonly property int ramTempCriticalThreshold: Plasmoid.configuration.ramTempCriticalThreshold || 85
-    readonly property int gpuWarningThreshold:      Plasmoid.configuration.gpuWarningThreshold      || 70
-    readonly property int gpuCriticalThreshold:     Plasmoid.configuration.gpuCriticalThreshold     || 90
-    readonly property int gpuTempWarningThreshold:  Plasmoid.configuration.gpuTempWarningThreshold  || 60
-    readonly property int gpuTempCriticalThreshold: Plasmoid.configuration.gpuTempCriticalThreshold || 85
-    readonly property int batteryWarningThreshold:  Plasmoid.configuration.batteryWarningThreshold  || 30
-    readonly property int batteryCriticalThreshold: Plasmoid.configuration.batteryCriticalThreshold || 15
-    readonly property int diskTempWarningThreshold: Plasmoid.configuration.diskTempWarningThreshold || 45
-    readonly property int diskTempCriticalThreshold: Plasmoid.configuration.diskTempCriticalThreshold || 60
+    function setGroup(key, patch) {
+        if (!patch || typeof patch !== "object") return;
+        if (patch.enabled !== undefined) setGroupEnabled(key, patch.enabled);
+        if (patch.visibility !== undefined) setVisibility(key, patch.visibility);
+        if (patch.label !== undefined) setGroupLabel(key, patch.label);
+        if (patch.subMetrics !== undefined) setSubMetrics(key, patch.subMetrics);
+    }
+
+    // Threshold colors
+    readonly property bool enableThresholdColors: Boolean(target && target[propertyPrefix + "enableThresholdColors"])
+    readonly property string warningColor:        (target && target[propertyPrefix + "warningColor"])  || "#e5a50a"
+    readonly property string criticalColor:       (target && target[propertyPrefix + "criticalColor"]) || "#da4453"
+
+    readonly property int cpuWarningThreshold:      (target && target[propertyPrefix + "cpuWarningThreshold"])      || 70
+    readonly property int cpuCriticalThreshold:     (target && target[propertyPrefix + "cpuCriticalThreshold"])     || 90
+    readonly property int tempWarningThreshold:     (target && target[propertyPrefix + "tempWarningThreshold"])     || 60
+    readonly property int tempCriticalThreshold:    (target && target[propertyPrefix + "tempCriticalThreshold"])    || 85
+    readonly property int systemWarningThreshold:   (target && target[propertyPrefix + "systemWarningThreshold"])   || 60
+    readonly property int systemCriticalThreshold:  (target && target[propertyPrefix + "systemCriticalThreshold"])  || 85
+    readonly property int ramWarningThreshold:      (target && target[propertyPrefix + "ramWarningThreshold"])      || 70
+    readonly property int ramCriticalThreshold:     (target && target[propertyPrefix + "ramCriticalThreshold"])     || 90
+    readonly property int swapWarningThreshold:     (target && target[propertyPrefix + "swapWarningThreshold"])     || 70
+    readonly property int swapCriticalThreshold:    (target && target[propertyPrefix + "swapCriticalThreshold"])    || 90
+    readonly property int ramTempWarningThreshold:  (target && target[propertyPrefix + "ramTempWarningThreshold"])  || 60
+    readonly property int ramTempCriticalThreshold: (target && target[propertyPrefix + "ramTempCriticalThreshold"]) || 85
+    readonly property int gpuWarningThreshold:      (target && target[propertyPrefix + "gpuWarningThreshold"])      || 70
+    readonly property int gpuCriticalThreshold:     (target && target[propertyPrefix + "gpuCriticalThreshold"])     || 90
+    readonly property int gpuTempWarningThreshold:  (target && target[propertyPrefix + "gpuTempWarningThreshold"])  || 60
+    readonly property int gpuTempCriticalThreshold: (target && target[propertyPrefix + "gpuTempCriticalThreshold"]) || 85
+    readonly property int batteryWarningThreshold:  (target && target[propertyPrefix + "batteryWarningThreshold"])  || 30
+    readonly property int batteryCriticalThreshold: (target && target[propertyPrefix + "batteryCriticalThreshold"]) || 15
+    readonly property int diskTempWarningThreshold: (target && target[propertyPrefix + "diskTempWarningThreshold"]) || 45
+    readonly property int diskTempCriticalThreshold: (target && target[propertyPrefix + "diskTempCriticalThreshold"]) || 60
 
     function getWarningThreshold(key) {
-        var val = root[key + "WarningThreshold"];
+        var prop = propertyPrefix + key + "WarningThreshold";
+        var val = target ? target[prop] : undefined;
         return val !== undefined ? val : 70;
     }
 
     function getCriticalThreshold(key) {
-        var val = root[key + "CriticalThreshold"];
+        var prop = propertyPrefix + key + "CriticalThreshold";
+        var val = target ? target[prop] : undefined;
         return val !== undefined ? val : 90;
     }
 
     // Units & hardware preferences
-    readonly property int updateInterval:         Plasmoid.configuration.updateInterval    || 2000
-    readonly property string tempUnit:            Plasmoid.configuration.tempUnit          || "C"
-    readonly property string networkUnit:         Plasmoid.configuration.networkUnit       || "bytes"
-    readonly property string fanUnit:             Plasmoid.configuration.fanUnit           || "rpm"
-    readonly property int fanMaxRpm:              Plasmoid.configuration.fanMaxRpm         || 2000
-    readonly property bool ramWidgetShowBoth:     Plasmoid.configuration.ramWidgetShowBoth || false
-    readonly property string batteryDevice:       Plasmoid.configuration.batteryDevice     || "auto"
-    readonly property string networkInterface:    Plasmoid.configuration.networkInterface  || "auto"
-    readonly property bool showNetworkIp:         Plasmoid.configuration.showNetworkIp     || false
-    readonly property string gpuSelection:        Plasmoid.configuration.gpuSelection      || ""
+    readonly property int updateInterval:         (target && target[propertyPrefix + "updateInterval"])    || 2000
+    readonly property string tempUnit:            (target && target[propertyPrefix + "tempUnit"])          || "C"
+    readonly property string networkUnit:         (target && target[propertyPrefix + "networkUnit"])       || "bytes"
+    readonly property string fanUnit:             (target && target[propertyPrefix + "fanUnit"])           || "rpm"
+    readonly property int fanMaxRpm:              (target && target[propertyPrefix + "fanMaxRpm"])         || 2000
+    readonly property bool ramWidgetShowBoth:     Boolean(target && target[propertyPrefix + "ramWidgetShowBoth"])
+    readonly property string batteryDevice:       (target && target[propertyPrefix + "batteryDevice"])     || "auto"
+    readonly property string networkInterface:    (target && target[propertyPrefix + "networkInterface"])  || "auto"
+    readonly property bool showNetworkIp:         Boolean(target && target[propertyPrefix + "showNetworkIp"])
+    readonly property string gpuSelection:        (target && target[propertyPrefix + "gpuSelection"])      || ""
 
-    // orderedKeys is the final display order for both views. It starts from
-    // metricOrder (user-defined), then appends any group keys missing from that
-    // list using ALL_GROUP_KEYS so new groups always appear rather than silently
-    // disappearing from the panel.
-    readonly property string metricOrder: Plasmoid.configuration.metricOrder || "cpu,ram,temp,gpu,bat,net,disk,fan,uptime"
+    // Order
+    readonly property string metricOrder: (target && target[propertyPrefix + "metricOrder"]) || "cpu,ram,temp,gpu,bat,net,disk,fan,uptime"
     readonly property var orderedKeys: {
         var all = Defs.ALL_GROUP_KEYS;
         var keys = metricOrder.split(",").map(function(k){ return k.trim(); }).filter(function(k){ return k.length > 0 && all.indexOf(k) >= 0; });
@@ -269,5 +309,181 @@ QtObject {
             if (keys.indexOf(all[i]) === -1) keys.push(all[i]);
         }
         return keys;
+    }
+
+    function moveMetric(fromIndex, toIndex) {
+        var keys = orderedKeys.slice();
+        if (fromIndex < 0 || fromIndex >= keys.length || toIndex < 0 || toIndex >= keys.length) return;
+        var item = keys.splice(fromIndex, 1)[0];
+        keys.splice(toIndex, 0, item);
+        var prop = propertyPrefix + "metricOrder";
+        if (target && target[prop] !== undefined) {
+            target[prop] = keys.join(",");
+        }
+    }
+
+    // Isolated device-specific configuration helpers: GPU
+    function parseGpuLabels() {
+        var str = gpuLabels;
+        var result = {};
+        if (!str) return result;
+        str.split("|").forEach(function(pair) {
+            var sep = pair.indexOf(":");
+            if (sep > 0) result[pair.substring(0, sep)] = pair.substring(sep + 1);
+        });
+        return result;
+    }
+
+    function saveGpuLabel(gpuId, label) {
+        var labels = parseGpuLabels();
+        var trimmed = (label || "").trim();
+        if (trimmed.length > 0) labels[gpuId] = trimmed;
+        else delete labels[gpuId];
+        var parts = [];
+        for (var id in labels) parts.push(id + ":" + labels[id]);
+        var prop = propertyPrefix + "gpuLabels";
+        if (target && target[prop] !== undefined) {
+            target[prop] = parts.join("|");
+        }
+    }
+
+    function isGpuSelected(gpuId) {
+        if (!gpuSelection || gpuSelection === "") return true;
+        if (gpuSelection === "none") return false;
+        return gpuSelection.split(",").indexOf(gpuId) >= 0;
+    }
+
+    function setGpuSelected(gpuId, checked, allGpuIds) {
+        var ids;
+        if (!gpuSelection || gpuSelection === "") {
+            ids = (allGpuIds || []).slice();
+        } else if (gpuSelection === "none") {
+            ids = [];
+        } else {
+            ids = gpuSelection.split(",").filter(function(s){ return s.length > 0; });
+        }
+        if (checked) {
+            if (ids.indexOf(gpuId) < 0) ids.push(gpuId);
+        } else {
+            ids = ids.filter(function(id){ return id !== gpuId; });
+        }
+        var all = allGpuIds || [];
+        var allSelected = all.length > 0 && all.every(function(id){ return ids.indexOf(id) >= 0; });
+        var val = "";
+        if (allSelected)           val = "";
+        else if (ids.length === 0) val = "none";
+        else                       val = ids.join(",");
+
+        var prop = propertyPrefix + "gpuSelection";
+        if (target && target[prop] !== undefined) {
+            target[prop] = val;
+        }
+    }
+
+    function parseGpuSubMetricsMap() {
+        var str = gpuSubMetrics;
+        var result = {};
+        if (!str) return result;
+        if (str.indexOf(":") >= 0) {
+            str.split("|").forEach(function(pair) {
+                var sep = pair.indexOf(":");
+                if (sep > 0) {
+                    var gid = pair.substring(0, sep);
+                    var subs = pair.substring(sep + 1).split(",").map(function(s){ return s.trim(); }).filter(function(s){ return s.length > 0; });
+                    result[gid] = subs;
+                }
+            });
+        }
+        return result;
+    }
+
+    function getGpuSubMetrics(gpuId) {
+        var map = parseGpuSubMetricsMap();
+        if (map[gpuId] && map[gpuId].length > 0) {
+            return map[gpuId];
+        }
+        if (gpuSubMetrics && gpuSubMetrics.indexOf(":") < 0) {
+            return gpuSubMetrics.split(",").map(function(s){ return s.trim(); }).filter(function(s){ return s.length > 0; });
+        }
+        return Defs.GROUPS.gpu.defaultSubMetrics.split(",").map(function(s){ return s.trim(); }).filter(function(s){ return s.length > 0; });
+    }
+
+    function toggleGpuSubMetric(gpuId, subKey, checked, allGpuIds) {
+        var map = parseGpuSubMetricsMap();
+        var all = allGpuIds || [gpuId];
+        for (var i = 0; i < all.length; i++) {
+            var gid = all[i];
+            if (!map[gid]) {
+                map[gid] = getGpuSubMetrics(gid);
+            }
+        }
+        var subs = map[gpuId] ? map[gpuId].slice() : getGpuSubMetrics(gpuId);
+        if (checked) {
+            if (subs.indexOf(subKey) < 0) subs.push(subKey);
+        } else {
+            if (subs.length > 1) {
+                subs = subs.filter(function(s){ return s !== subKey; });
+            }
+        }
+        map[gpuId] = subs;
+
+        var parts = [];
+        for (var id in map) {
+            parts.push(id + ":" + map[id].join(","));
+        }
+        var prop = propertyPrefix + "gpuSubMetrics";
+        if (target && target[prop] !== undefined) {
+            target[prop] = parts.join("|");
+        }
+    }
+
+    // Isolated device-specific configuration helpers: Disk
+    function parseDiskLabels() {
+        var str = diskLabels;
+        var result = {};
+        if (!str) return result;
+        str.split("|").forEach(function(pair) {
+            var sep = pair.indexOf(":");
+            if (sep > 0) result[pair.substring(0, sep)] = pair.substring(sep + 1);
+        });
+        return result;
+    }
+
+    function saveDiskLabel(diskId, label) {
+        var labels = parseDiskLabels();
+        var trimmed = (label || "").trim();
+        if (trimmed.length > 0) labels[diskId] = trimmed;
+        else delete labels[diskId];
+        var parts = [];
+        for (var id in labels) parts.push(id + ":" + labels[id]);
+        var prop = propertyPrefix + "diskLabels";
+        if (target && target[prop] !== undefined) {
+            target[prop] = parts.join("|");
+        }
+    }
+
+    // Isolated device-specific configuration helpers: Fan
+    function parseFanLabels() {
+        var str = fanLabels;
+        var result = Object.create(null);
+        if (!str) return result;
+        str.split("|").forEach(function(pair) {
+            var sep = pair.indexOf(":");
+            if (sep > 0) result[pair.substring(0, sep)] = pair.substring(sep + 1);
+        });
+        return result;
+    }
+
+    function saveFanLabel(fanId, label) {
+        var labels = parseFanLabels();
+        var trimmed = (label || "").replace(/\|/g, "").trim();
+        if (trimmed.length > 0) labels[fanId] = trimmed;
+        else delete labels[fanId];
+        var parts = [];
+        for (var id in labels) parts.push(id + ":" + labels[id]);
+        var prop = propertyPrefix + "fanLabels";
+        if (target && target[prop] !== undefined) {
+            target[prop] = parts.join("|");
+        }
     }
 }

--- a/contents/ui/models/MetricDefinitions.js
+++ b/contents/ui/models/MetricDefinitions.js
@@ -6,63 +6,113 @@
 var GROUPS = {
     cpu: {
         id: "cpu",
+        name: "CPU",
         defaultLabel: "CPU",
         defaultIcon: "am-cpu-symbolic",
-        defaultSubMetrics: "usage,freq,temp"
+        defaultSubMetrics: "usage,freq,temp",
+        subs: [
+            { key: "usage", label: "Usage" },
+            { key: "freq",  label: "Frequency" },
+            { key: "temp",  label: "Temperature" }
+        ]
     },
     ram: {
         id: "ram",
+        name: "RAM",
         defaultLabel: "RAM",
         defaultIcon: "nvidia-ram-symbolic",
-        defaultSubMetrics: "percentage"
+        defaultSubMetrics: "percentage",
+        subs: [
+            { key: "percentage", label: "Percentage" },
+            { key: "used",       label: "Used / Total" },
+            { key: "temp",       label: "Temperature (DDR5)" }
+        ]
     },
     swap: {
         id: "swap",
+        name: "Swap",
         defaultLabel: "SWAP",
         defaultIcon: "nvidia-ram-symbolic",
-        defaultSubMetrics: "percent,used"
+        defaultSubMetrics: "percent,used",
+        subs: [
+            { key: "percent", label: "Usage (%)" },
+            { key: "used",    label: "Used" },
+            { key: "free",    label: "Free" },
+            { key: "total",   label: "Total" }
+        ]
     },
     temp: {
         id: "temp",
+        name: "Temperature",
         defaultLabel: "System",
         defaultIcon: "temperature-normal",
-        defaultSubMetrics: "temp"
+        defaultSubMetrics: "temp",
+        subs: []
     },
     gpu: {
         id: "gpu",
+        name: "GPU",
         defaultLabel: "GPU",
         defaultIcon: "gpu-symbolic",
-        defaultSubMetrics: "usage,vram,temp"
+        defaultSubMetrics: "usage,vram,temp",
+        subs: [
+            { key: "usage", label: "Usage" },
+            { key: "vram",  label: "VRAM" },
+            { key: "temp",  label: "Temperature" },
+            { key: "freq",  label: "Frequency" },
+            { key: "power", label: "Power" }
+        ]
     },
     bat: {
         id: "bat",
+        name: "Battery",
         defaultLabel: "BAT",
         defaultIcon: "battery-good",
-        defaultSubMetrics: "percentage,power"
+        defaultSubMetrics: "percentage,power",
+        subs: [
+            { key: "percentage", label: "Percentage" },
+            { key: "power",      label: "Power consumption" }
+        ]
     },
     net: {
         id: "net",
+        name: "Network",
         defaultLabel: "NET",
         defaultIcon: "network-wireless",
-        defaultSubMetrics: "down,up"
+        defaultSubMetrics: "down,up",
+        subs: [
+            { key: "down", label: "Download" },
+            { key: "up",   label: "Upload" },
+            { key: "ip",   label: "IP address" }
+        ]
     },
     disk: {
         id: "disk",
+        name: "Disk",
         defaultLabel: "DSK",
         defaultIcon: "am-disk-utility-symbolic",
-        defaultSubMetrics: "read,write"
+        defaultSubMetrics: "read,write",
+        subs: [
+            { key: "read",  label: "Read" },
+            { key: "write", label: "Write" },
+            { key: "temp",  label: "Temperature" }
+        ]
     },
     fan: {
         id: "fan",
+        name: "Fan",
         defaultLabel: "FAN",
         defaultIcon: "am-fan-symbolic",
-        defaultSubMetrics: "speed"
+        defaultSubMetrics: "speed",
+        subs: []
     },
     uptime: {
         id: "uptime",
+        name: "System Uptime",
         defaultLabel: "UPTIME",
         defaultIcon: "clock",
-        defaultSubMetrics: "uptime"
+        defaultSubMetrics: "uptime",
+        subs: []
     }
 };
 

--- a/contents/ui/models/MetricDefinitions.js
+++ b/contents/ui/models/MetricDefinitions.js
@@ -58,9 +58,7 @@ var GROUPS = {
         subs: [
             { key: "usage", label: "Usage" },
             { key: "vram",  label: "VRAM" },
-            { key: "temp",  label: "Temperature" },
-            { key: "freq",  label: "Frequency" },
-            { key: "power", label: "Power" }
+            { key: "temp",  label: "Temperature" }
         ]
     },
     bat: {


### PR DESCRIPTION
## Description

- **Metadata centralization (`MetricDefinitions.js`)**:
  - Added `name`, `defaultLabel`, and `subs` metadata definitions directly to `GROUPS`.
  - Removed duplicate `metricMeta` dictionary from `configMetrics.qml`.

- **Generic configuration APIs (`MetricConfig.qml`)**:
  - Added generic helper methods: `getGroup()`, `setGroup()`, `getSubMetrics()`, `setSubMetrics()`, `toggleSubMetric()`, `isGroupEnabled()`, `setGroupEnabled()`, `getVisibility()`, `setVisibility()`, `getGroupLabel()`, `setGroupLabel()`, `getGroupIcon()`, and `moveMetric()`.
  - Replaced switch/case dispatch with property lookup maps (`_enabledMap`, `_subMetricsMap`, `_visibilityMap`, etc.).
  - Added support for targeting either `Plasmoid.configuration` (runtime) or `KCM.SimpleKCM` (`cfg_` prefixed properties).

- **Generic GPU sub-metrics**:
  - Replaced hard-coded GPU checkboxes with the generic `Repeater { model: catDelegate.meta.subs }`.
  - GPU sub-metrics now use the same metadata pipeline as CPU, RAM, Disk, and Network.

- **Isolated device settings**:
  - Moved GPU, Disk, and Fan label and selection serialization helpers into `MetricConfig.qml` while keeping hardware discovery in `configMetrics.qml`.

- **Preserved existing behavior**:
  - Preserved all existing KConfigXT properties and defaults.
  - Kept special-case controls (RAM popup override, DDR5 hint, chipset fallback hint, fan max RPM fallback, network interface selector).



