### PR TITLE
feat: add per-core CPU, Wi-Fi signal, network totals and optimize hardware discovery

### DIFF
--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -4,7 +4,6 @@ import QtQuick.Layouts
 import org.kde.kirigami as Kirigami
 import org.kde.kcmutils as KCM
 import org.kde.plasma.plasmoid
-import org.kde.plasma.plasma5support as Plasma5Support
 import org.kde.ksysguard.sensors as Sensors
 import "./models"
 import "./models/MetricDefinitions.js" as MetricDefinitions
@@ -59,41 +58,11 @@ KCM.SimpleKCM {
         id: discovery
     }
 
-    // GPU discovery
-    readonly property var discoveredGpus: {
-        var pattern = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.GPU : /^gpu\/(gpu\d+)\/usage$/;
-        var ids = discovery.revision >= 0 ? discovery.queryIds(pattern) : [];
-        var found = [];
-        for (var i = 0; i < ids.length; i++) {
-            var match = ids[i].match(pattern);
-            if (match) {
-                found.push({ id: match[1], name: "GPU " + (found.length + 1) });
-            }
-        }
-        return found;
-    }
-
-    // Disk discovery
-    readonly property var discoveredDisks: {
-        var pattern = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.DISK_READ : /^disk\/(nvme\d+n\d+|sd[a-z]+)\/read$/;
-        var ids = discovery.revision >= 0 ? discovery.queryIds(pattern) : [];
-        var found = [];
-        for (var i = 0; i < ids.length; i++) {
-            var match = ids[i].match(pattern);
-            if (match && !found.some(function(d){ return d.id === match[1]; })) {
-                found.push({ id: match[1], name: "Disk " + (found.length + 1) });
-            }
-        }
-        return found;
-    }
-
-    // Fan discovery
-    readonly property var discoveredFans: {
-        var pattern = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.FAN : /^(lmsensors|cpu|gpu)\/.*\/fan\d+$/i;
-        var ids = discovery.revision >= 0 ? discovery.queryIds(pattern) : [];
-        ids.sort();
-        return ids.map(function(id, i) { return { id: id, name: "Fan " + (i + 1) }; });
-    }
+    // Direct O(1) hardware discovery bindings
+    readonly property var discoveredGpus: discovery.discoveredGpus
+    readonly property var discoveredDisks: discovery.discoveredDisks
+    readonly property var discoveredFans: discovery.discoveredFans
+    readonly property var ifaceList: discovery.discoveredNetworkIfaces
 
     // Fan max-RPM check
     property bool fanMaxFallbackNeeded: true
@@ -121,261 +90,285 @@ KCM.SimpleKCM {
         fanMaxFallbackNeeded = false;
     }
 
-    // Network interface discovery
-    property var ifaceList: ["auto"]
-    Plasma5Support.DataSource {
-        id: ifaceSource
-        engine: "executable"
-        connectedSources: ["ls /sys/class/net/"]
-        onNewData: function (source, data) {
-            if (data["exit code"] !== 0) return;
-            var raw = data["stdout"].trim();
-            if (raw.length === 0) return;
-            var ifaces = raw.split("\n").filter(function (name) {
-                return name !== "lo" && name.length > 0;
-            });
-            ifaces.unshift("auto");
-            metricsPage.ifaceList = ifaces;
-        }
-    }
-
     // UI
-    Kirigami.FormLayout {
+    ColumnLayout {
+        spacing: 0
+        Layout.fillWidth: true
 
         // ── Processor (CPU) ────────────────────────────────────────────────
+        Kirigami.FormLayout {
+            id: cpuForm
+            Layout.fillWidth: true
+            twinFormLayouts: [cpuForm, memForm, tempForm, gpuForm, batForm, netForm, diskForm, fanForm]
 
-        Kirigami.Separator {
-            Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: i18n("Processor (CPU)")
-        }
+            Kirigami.Separator {
+                Kirigami.FormData.isSection: true
+                Kirigami.FormData.label: i18n("Processor (CPU)")
+            }
 
-        TextField {
-            Kirigami.FormData.label: i18n("Display label:")
-            text: cfg_cpuLabel
-            placeholderText: "CPU"
-            implicitWidth: Kirigami.Units.gridUnit * 14
-            onTextEdited: cfg_cpuLabel = text.trim() || "CPU"
+            TextField {
+                Kirigami.FormData.label: i18n("Display label:")
+                text: cfg_cpuLabel
+                placeholderText: "CPU"
+                implicitWidth: Kirigami.Units.gridUnit * 14
+                onTextEdited: cfg_cpuLabel = text.trim() || "CPU"
+            }
         }
 
         // ── Memory (RAM & Swap) ────────────────────────────────────────────
+        Kirigami.FormLayout {
+            id: memForm
+            Layout.fillWidth: true
+            twinFormLayouts: [cpuForm, memForm, tempForm, gpuForm, batForm, netForm, diskForm, fanForm]
 
-        Kirigami.Separator {
-            Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: i18n("Memory (RAM & Swap)")
-        }
+            Kirigami.Separator {
+                Kirigami.FormData.isSection: true
+                Kirigami.FormData.label: i18n("Memory (RAM & Swap)")
+            }
 
-        TextField {
-            Kirigami.FormData.label: i18n("RAM label:")
-            text: cfg_ramLabel
-            placeholderText: "RAM"
-            implicitWidth: Kirigami.Units.gridUnit * 14
-            onTextEdited: cfg_ramLabel = text.trim() || "RAM"
-        }
+            TextField {
+                Kirigami.FormData.label: i18n("RAM label:")
+                text: cfg_ramLabel
+                placeholderText: "RAM"
+                implicitWidth: Kirigami.Units.gridUnit * 14
+                onTextEdited: cfg_ramLabel = text.trim() || "RAM"
+            }
 
-        TextField {
-            Kirigami.FormData.label: i18n("Swap label:")
-            text: cfg_swapLabel
-            placeholderText: "SWAP"
-            implicitWidth: Kirigami.Units.gridUnit * 14
-            onTextEdited: cfg_swapLabel = text.trim() || "SWAP"
+            TextField {
+                Kirigami.FormData.label: i18n("Swap label:")
+                text: cfg_swapLabel
+                placeholderText: "SWAP"
+                implicitWidth: Kirigami.Units.gridUnit * 14
+                onTextEdited: cfg_swapLabel = text.trim() || "SWAP"
+            }
         }
 
         // ── Temperature ────────────────────────────────────────────────────
+        Kirigami.FormLayout {
+            id: tempForm
+            Layout.fillWidth: true
+            twinFormLayouts: [cpuForm, memForm, tempForm, gpuForm, batForm, netForm, diskForm, fanForm]
 
-        Kirigami.Separator {
-            Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: i18n("Temperature")
-        }
+            Kirigami.Separator {
+                Kirigami.FormData.isSection: true
+                Kirigami.FormData.label: i18n("Temperature")
+            }
 
-        TextField {
-            Kirigami.FormData.label: i18n("System temp label:")
-            text: cfg_tempLabel
-            placeholderText: "System"
-            implicitWidth: Kirigami.Units.gridUnit * 14
-            onTextEdited: cfg_tempLabel = text.trim() || "System"
+            TextField {
+                Kirigami.FormData.label: i18n("System temp label:")
+                text: cfg_tempLabel
+                placeholderText: "System"
+                implicitWidth: Kirigami.Units.gridUnit * 14
+                onTextEdited: cfg_tempLabel = text.trim() || "System"
+            }
         }
 
         // ── Graphics (GPU) ─────────────────────────────────────────────────
+        Kirigami.FormLayout {
+            id: gpuForm
+            Layout.fillWidth: true
+            twinFormLayouts: [cpuForm, memForm, tempForm, gpuForm, batForm, netForm, diskForm, fanForm]
 
-        Kirigami.Separator {
-            Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: i18n("Graphics (GPU)")
-        }
+            Kirigami.Separator {
+                Kirigami.FormData.isSection: true
+                Kirigami.FormData.label: i18n("Graphics (GPU)")
+            }
 
-        Label {
-            visible: metricsPage.discoveredGpus.length === 0
-            text: i18n("No GPU detected")
-            opacity: 0.7
-            font.italic: true
-        }
+            Label {
+                visible: metricsPage.discoveredGpus.length === 0
+                text: i18n("No GPU detected")
+                opacity: 0.7
+                font.italic: true
+            }
 
-        Repeater {
-            id: gpuSelectorRepeater
-            model: metricsPage.discoveredGpus
+            Repeater {
+                id: gpuSelectorRepeater
+                model: metricsPage.discoveredGpus
 
-            delegate: RowLayout {
-                id: gpuDelegate
-                required property var modelData
-                Kirigami.FormData.label: gpuDelegate.modelData.name + " (" + gpuDelegate.modelData.id + "):"
-                spacing: Kirigami.Units.smallSpacing
+                delegate: RowLayout {
+                    id: gpuDelegate
+                    required property var modelData
+                    Kirigami.FormData.label: gpuDelegate.modelData.name + " (" + gpuDelegate.modelData.id + "):"
+                    spacing: Kirigami.Units.smallSpacing
 
-                property bool _gpuEnabled: metricConfig.isGpuSelected(modelData.id)
+                    property bool _gpuEnabled: metricConfig.isGpuSelected(modelData.id)
 
-                CheckBox {
-                    text: i18n("Enabled")
-                    checked: gpuDelegate._gpuEnabled
-                    onToggled: {
-                        var allIds = gpuSelectorRepeater.model.map(function(g){ return g.id; });
-                        metricConfig.setGpuSelected(modelData.id, checked, allIds);
+                    CheckBox {
+                        text: i18n("Enabled")
+                        checked: gpuDelegate._gpuEnabled
+                        onToggled: {
+                            var allIds = gpuSelectorRepeater.model.map(function(g){ return g.id; });
+                            metricConfig.setGpuSelected(modelData.id, checked, allIds);
+                        }
                     }
-                }
 
-                TextField {
-                    implicitWidth: Kirigami.Units.gridUnit * 12
-                    text: metricConfig.parseGpuLabels()[gpuDelegate.modelData.id] || ""
-                    placeholderText: gpuDelegate.modelData.name
-                    onTextEdited: metricConfig.saveGpuLabel(gpuDelegate.modelData.id, text)
-                }
+                    TextField {
+                        implicitWidth: Kirigami.Units.gridUnit * 12
+                        text: metricConfig.parseGpuLabels()[gpuDelegate.modelData.id] || ""
+                        placeholderText: gpuDelegate.modelData.name
+                        onTextEdited: metricConfig.saveGpuLabel(gpuDelegate.modelData.id, text)
+                    }
 
-                Kirigami.ContextualHelpButton {
-                    visible: metricsPage.discoveredGpus.length > 1
-                    toolTipText: i18n("On hybrid-GPU laptops, uncheck the discrete GPU to allow it to power down and save battery.")
+                    Kirigami.ContextualHelpButton {
+                        visible: metricsPage.discoveredGpus.length > 1
+                        toolTipText: i18n("On hybrid-GPU laptops, uncheck the discrete GPU to allow it to power down and save battery.")
+                    }
                 }
             }
         }
 
         // ── Battery & Power ────────────────────────────────────────────────
+        Kirigami.FormLayout {
+            id: batForm
+            Layout.fillWidth: true
+            twinFormLayouts: [cpuForm, memForm, tempForm, gpuForm, batForm, netForm, diskForm, fanForm]
 
-        Kirigami.Separator {
-            Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: i18n("Battery & Power")
-        }
-
-        TextField {
-            Kirigami.FormData.label: i18n("Display label:")
-            text: cfg_batLabel
-            placeholderText: "BAT"
-            implicitWidth: Kirigami.Units.gridUnit * 14
-            onTextEdited: cfg_batLabel = text.trim() || "BAT"
-        }
-
-        RowLayout {
-            Kirigami.FormData.label: i18n("Battery device:")
-            spacing: Kirigami.Units.smallSpacing
-
-            TextField {
-                text: cfg_batteryDevice === "auto" ? "" : cfg_batteryDevice
-                placeholderText: i18n("Auto-detect (e.g. BAT0)")
-                implicitWidth: Kirigami.Units.gridUnit * 14
-                onTextEdited: {
-                    var v = text.trim();
-                    cfg_batteryDevice = v.length > 0 ? v : "auto";
-                }
+            Kirigami.Separator {
+                Kirigami.FormData.isSection: true
+                Kirigami.FormData.label: i18n("Battery & Power")
             }
 
-            Kirigami.ContextualHelpButton {
-                toolTipText: i18n("Leave empty for automatic detection. Specify a custom sysfs battery device name (e.g. BAT0, BAT1) if multiple batteries are installed.")
+            TextField {
+                Kirigami.FormData.label: i18n("Display label:")
+                text: cfg_batLabel
+                placeholderText: "BAT"
+                implicitWidth: Kirigami.Units.gridUnit * 14
+                onTextEdited: cfg_batLabel = text.trim() || "BAT"
+            }
+
+            RowLayout {
+                Kirigami.FormData.label: i18n("Battery device:")
+                spacing: Kirigami.Units.smallSpacing
+
+                TextField {
+                    text: cfg_batteryDevice === "auto" ? "" : cfg_batteryDevice
+                    placeholderText: i18n("Auto-detect (e.g. BAT0)")
+                    implicitWidth: Kirigami.Units.gridUnit * 14
+                    onTextEdited: {
+                        var v = text.trim();
+                        cfg_batteryDevice = v.length > 0 ? v : "auto";
+                    }
+                }
+
+                Kirigami.ContextualHelpButton {
+                    toolTipText: i18n("Leave empty for automatic detection. Specify a custom sysfs battery device name (e.g. BAT0, BAT1) if multiple batteries are installed.")
+                }
             }
         }
 
         // ── Network ────────────────────────────────────────────────────────
+        Kirigami.FormLayout {
+            id: netForm
+            Layout.fillWidth: true
+            twinFormLayouts: [cpuForm, memForm, tempForm, gpuForm, batForm, netForm, diskForm, fanForm]
 
-        Kirigami.Separator {
-            Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: i18n("Network")
-        }
-
-        ComboBox {
-            id: ifaceCombo
-            Kirigami.FormData.label: i18n("Interface:")
-            model: metricsPage.ifaceList
-            currentIndex: {
-                var idx = metricsPage.ifaceList.indexOf(cfg_networkInterface);
-                return idx >= 0 ? idx : 0;
+            Kirigami.Separator {
+                Kirigami.FormData.isSection: true
+                Kirigami.FormData.label: i18n("Network")
             }
-            onActivated: cfg_networkInterface = metricsPage.ifaceList[currentIndex]
-            implicitWidth: Kirigami.Units.gridUnit * 14
-        }
 
-        TextField {
-            Kirigami.FormData.label: i18n("Display label:")
-            text: cfg_netLabel
-            placeholderText: "NET"
-            implicitWidth: Kirigami.Units.gridUnit * 14
-            onTextEdited: cfg_netLabel = text.trim() || "NET"
+            ComboBox {
+                id: ifaceCombo
+                Kirigami.FormData.label: i18n("Interface:")
+                model: metricsPage.ifaceList
+                currentIndex: {
+                    var idx = metricsPage.ifaceList.indexOf(cfg_networkInterface);
+                    return idx >= 0 ? idx : 0;
+                }
+                onActivated: cfg_networkInterface = metricsPage.ifaceList[currentIndex]
+                implicitWidth: Kirigami.Units.gridUnit * 14
+            }
+
+            TextField {
+                Kirigami.FormData.label: i18n("Display label:")
+                text: cfg_netLabel
+                placeholderText: "NET"
+                implicitWidth: Kirigami.Units.gridUnit * 14
+                onTextEdited: cfg_netLabel = text.trim() || "NET"
+            }
         }
 
         // ── Storage (Disks) ────────────────────────────────────────────────
+        Kirigami.FormLayout {
+            id: diskForm
+            Layout.fillWidth: true
+            twinFormLayouts: [cpuForm, memForm, tempForm, gpuForm, batForm, netForm, diskForm, fanForm]
 
-        Kirigami.Separator {
-            Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: i18n("Storage (Disks)")
-        }
+            Kirigami.Separator {
+                Kirigami.FormData.isSection: true
+                Kirigami.FormData.label: i18n("Storage (Disks)")
+            }
 
-        TextField {
-            Kirigami.FormData.label: i18n("Global disk label:")
-            text: cfg_diskLabel
-            placeholderText: "DSK"
-            implicitWidth: Kirigami.Units.gridUnit * 14
-            onTextEdited: cfg_diskLabel = text.trim() || "DSK"
-        }
-
-        Repeater {
-            model: metricsPage.discoveredDisks
-
-            delegate: TextField {
-                required property var modelData
-                Kirigami.FormData.label: modelData.name + " (" + modelData.id + "):"
+            TextField {
+                Kirigami.FormData.label: i18n("Global disk label:")
+                text: cfg_diskLabel
+                placeholderText: "DSK"
                 implicitWidth: Kirigami.Units.gridUnit * 14
-                text: metricConfig.parseDiskLabels()[modelData.id] || ""
-                placeholderText: modelData.name
-                onTextEdited: metricConfig.saveDiskLabel(modelData.id, text)
+                onTextEdited: cfg_diskLabel = text.trim() || "DSK"
+            }
+
+            Repeater {
+                model: metricsPage.discoveredDisks
+
+                delegate: TextField {
+                    required property var modelData
+                    Kirigami.FormData.label: modelData.name + " (" + modelData.id + "):"
+                    implicitWidth: Kirigami.Units.gridUnit * 14
+                    text: metricConfig.parseDiskLabels()[modelData.id] || ""
+                    placeholderText: modelData.name
+                    onTextEdited: metricConfig.saveDiskLabel(modelData.id, text)
+                }
             }
         }
 
         // ── Cooling (Fans) ─────────────────────────────────────────────────
+        Kirigami.FormLayout {
+            id: fanForm
+            Layout.fillWidth: true
+            twinFormLayouts: [cpuForm, memForm, tempForm, gpuForm, batForm, netForm, diskForm, fanForm]
 
-        Kirigami.Separator {
-            Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: i18n("Cooling (Fans)")
-        }
+            Kirigami.Separator {
+                Kirigami.FormData.isSection: true
+                Kirigami.FormData.label: i18n("Cooling (Fans)")
+            }
 
-        TextField {
-            Kirigami.FormData.label: i18n("Global fan label:")
-            text: cfg_fanLabel
-            placeholderText: "FAN"
-            implicitWidth: Kirigami.Units.gridUnit * 14
-            onTextEdited: cfg_fanLabel = text.trim() || "FAN"
-        }
-
-        Repeater {
-            model: metricsPage.discoveredFans
-
-            delegate: TextField {
-                required property var modelData
-                Kirigami.FormData.label: modelData.name + ":"
+            TextField {
+                Kirigami.FormData.label: i18n("Global fan label:")
+                text: cfg_fanLabel
+                placeholderText: "FAN"
                 implicitWidth: Kirigami.Units.gridUnit * 14
-                text: metricConfig.parseFanLabels()[modelData.id] || ""
-                placeholderText: modelData.name
-                onTextEdited: metricConfig.saveFanLabel(modelData.id, text)
-            }
-        }
-
-        RowLayout {
-            visible: metricsPage.fanMaxFallbackNeeded
-            Kirigami.FormData.label: i18n("Max RPM fallback:")
-            spacing: Kirigami.Units.smallSpacing
-
-            SpinBox {
-                from: 500
-                to: 9999
-                stepSize: 100
-                value: cfg_fanMaxRpm
-                onValueChanged: cfg_fanMaxRpm = value
+                onTextEdited: cfg_fanLabel = text.trim() || "FAN"
             }
 
-            Kirigami.ContextualHelpButton {
-                toolTipText: i18n("Used as the maximum baseline RPM to calculate fan speed percentage when the hardware driver does not report a maximum RPM.")
+            RowLayout {
+                visible: metricsPage.fanMaxFallbackNeeded
+                Kirigami.FormData.label: i18n("Max RPM fallback:")
+                spacing: Kirigami.Units.smallSpacing
+
+                SpinBox {
+                    from: 500
+                    to: 9999
+                    stepSize: 100
+                    value: cfg_fanMaxRpm
+                    onValueChanged: cfg_fanMaxRpm = value
+                }
+
+                Kirigami.ContextualHelpButton {
+                    toolTipText: i18n("Used as the maximum baseline RPM to calculate fan speed percentage when the hardware driver does not report a maximum RPM.")
+                }
+            }
+
+            Repeater {
+                model: metricsPage.discoveredFans
+
+                delegate: TextField {
+                    required property var modelData
+                    Kirigami.FormData.label: modelData.name + ":"
+                    implicitWidth: Kirigami.Units.gridUnit * 14
+                    text: metricConfig.parseFanLabels()[modelData.id] || ""
+                    placeholderText: modelData.name
+                    onTextEdited: metricConfig.saveFanLabel(modelData.id, text)
+                }
             }
         }
     }

--- a/contents/ui/configPanelOrder.qml
+++ b/contents/ui/configPanelOrder.qml
@@ -124,7 +124,13 @@ KCM.SimpleKCM {
         // Mockup preview values
         var previewVal = "";
         if (group === "cpu") {
-            previewVal = subKey === "usage" ? "22%" : (subKey === "freq" ? "3.6 GHz" : (subKey === "temp" ? "62°C" : (subKey === "load1" ? "1.20" : (subKey === "load5" ? "1.05" : (subKey === "load15" ? "0.95" : "22%")))));
+            if (subKey === "core") {
+                var cNum = parseInt(devId.replace("cpu", ""), 10);
+                displayName = "Core " + (!isNaN(cNum) ? (cNum + 1) : devId);
+                previewVal = "28%";
+            } else {
+                previewVal = subKey === "usage" ? "22%" : (subKey === "freq" ? "3.6 GHz" : (subKey === "temp" ? "62°C" : (subKey === "load1" ? "1.20" : (subKey === "load5" ? "1.05" : (subKey === "load15" ? "0.95" : "22%")))));
+            }
         } else if (group === "ram") {
             previewVal = subKey === "percentage" ? "35%" : (subKey === "used" ? "8.4/32G" : "42°C");
         } else if (group === "swap") {
@@ -134,7 +140,18 @@ KCM.SimpleKCM {
         } else if (group === "bat") {
             previewVal = subKey === "percentage" ? "85%" : (subKey === "power" ? "14.2W" : (subKey === "health" ? "98%" : "85%"));
         } else if (group === "net") {
-            previewVal = subKey === "down" ? "↓ 1.2MB" : (subKey === "up" ? "↑ 240KB" : "192.168.1.1");
+            if (subKey === "signal") {
+                icon = "network-wireless-symbolic";
+                previewVal = "78%";
+            } else if (subKey === "totalDown") {
+                icon = "network-download-symbolic";
+                previewVal = "1.24 GB";
+            } else if (subKey === "totalUp") {
+                icon = "network-upload-symbolic";
+                previewVal = "240 MB";
+            } else {
+                previewVal = subKey === "down" ? "↓ 1.2MB" : (subKey === "up" ? "↑ 240KB" : "192.168.1.1");
+            }
         } else if (group === "disk") {
             previewVal = subKey === "read" ? "↓ 45MB" : (subKey === "write" ? "↑ 12MB" : (subKey === "usage" ? "45%" : (subKey === "space" ? "220/512G" : "54°C")));
         } else if (group === "fan") {
@@ -162,17 +179,22 @@ KCM.SimpleKCM {
         var cats = [];
 
         // 1. Processor (CPU)
+        var cores = discovery.discoveredCores || [];
+        var cpuItems = [
+            { id: "cpu/usage", label: i18n("CPU Usage"), icon: "cpu-symbolic" },
+            { id: "cpu/freq", label: i18n("CPU Frequency"), icon: "cpu-symbolic" },
+            { id: "cpu/temp", label: i18n("CPU Temperature"), icon: "temperature-symbolic" },
+            { id: "cpu/load1", label: i18n("CPU Load (1m)"), icon: "cpu-symbolic" },
+            { id: "cpu/load5", label: i18n("CPU Load (5m)"), icon: "cpu-symbolic" },
+            { id: "cpu/load15", label: i18n("CPU Load (15m)"), icon: "cpu-symbolic" }
+        ];
+        for (var ci = 0; ci < cores.length; ci++) {
+            cpuItems.push({ id: "cpu:" + cores[ci].id + "/core", label: cores[ci].name, icon: "cpu-symbolic" });
+        }
         cats.push({
             title: i18n("Processor (CPU)"),
             icon: "cpu-symbolic",
-            items: [
-                { id: "cpu/usage", label: i18n("CPU Usage"), icon: "cpu-symbolic" },
-                { id: "cpu/freq", label: i18n("CPU Frequency"), icon: "cpu-symbolic" },
-                { id: "cpu/temp", label: i18n("CPU Temperature"), icon: "temperature-symbolic" },
-                { id: "cpu/load1", label: i18n("CPU Load (1m)"), icon: "cpu-symbolic" },
-                { id: "cpu/load5", label: i18n("CPU Load (5m)"), icon: "cpu-symbolic" },
-                { id: "cpu/load15", label: i18n("CPU Load (15m)"), icon: "cpu-symbolic" }
-            ]
+            items: cpuItems
         });
 
         // 2. Memory (RAM & Swap)
@@ -208,32 +230,35 @@ KCM.SimpleKCM {
         });
 
         // 5. Network
+        var netItems = [
+            { id: "net/down", label: i18n("Download"), icon: "network-download-symbolic" },
+            { id: "net/up", label: i18n("Upload"), icon: "network-upload-symbolic" },
+            { id: "net/totalDown", label: i18n("Total Download"), icon: "network-download-symbolic" },
+            { id: "net/totalUp", label: i18n("Total Upload"), icon: "network-upload-symbolic" },
+            { id: "net/ip", label: i18n("Local IP"), icon: "network-symbolic" }
+        ];
+        var hasWifi = discovery.queryIds(/^network\/[^/]+\/signal$/).length > 0;
+        if (hasWifi) {
+            netItems.push({ id: "net/signal", label: i18n("Wi-Fi Signal"), icon: "network-wireless-symbolic" });
+        }
         cats.push({
             title: i18n("Network"),
             icon: "network-symbolic",
-            items: [
-                { id: "net/down", label: i18n("Download"), icon: "network-download-symbolic" },
-                { id: "net/up", label: i18n("Upload"), icon: "network-upload-symbolic" },
-                { id: "net/ip", label: i18n("Local IP"), icon: "network-symbolic" }
-            ]
+            items: netItems
         });
 
         // 6. Graphics (GPU)
-        var gPattern = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.GPU : /^gpu\/(gpu\d+)\/usage$/;
-        var gIds = discovery.queryIds(gPattern);
-        if (gIds.length > 0) {
+        var gpus = discovery.discoveredGpus || [];
+        if (gpus.length > 0) {
             var gpuItems = [];
-            for (var gi = 0; gi < gIds.length; gi++) {
-                var gm = gIds[gi].match(gPattern);
-                if (gm) {
-                    var gid = gm[1];
-                    var gName = "GPU " + (gi + 1);
-                    gpuItems.push({ id: "gpu:" + gid + "/usage", label: gName + " Usage", icon: "gpu-symbolic" });
-                    gpuItems.push({ id: "gpu:" + gid + "/vram", label: gName + " VRAM", icon: "gpu-symbolic" });
-                    gpuItems.push({ id: "gpu:" + gid + "/temp", label: gName + " Temp", icon: "temperature-symbolic" });
-                    gpuItems.push({ id: "gpu:" + gid + "/freq", label: gName + " Frequency", icon: "gpu-symbolic" });
-                    gpuItems.push({ id: "gpu:" + gid + "/power", label: gName + " Power", icon: "voltage-symbolic" });
-                }
+            for (var gi = 0; gi < gpus.length; gi++) {
+                var gid = gpus[gi].id;
+                var gName = gpus[gi].name;
+                gpuItems.push({ id: "gpu:" + gid + "/usage", label: gName + " Usage", icon: "gpu-symbolic" });
+                gpuItems.push({ id: "gpu:" + gid + "/vram", label: gName + " VRAM", icon: "gpu-symbolic" });
+                gpuItems.push({ id: "gpu:" + gid + "/temp", label: gName + " Temp", icon: "temperature-symbolic" });
+                gpuItems.push({ id: "gpu:" + gid + "/freq", label: gName + " Frequency", icon: "gpu-symbolic" });
+                gpuItems.push({ id: "gpu:" + gid + "/power", label: gName + " Power", icon: "voltage-symbolic" });
             }
             cats.push({
                 title: i18n("Graphics (GPU)"),
@@ -243,23 +268,17 @@ KCM.SimpleKCM {
         }
 
         // 7. Storage (Disks)
-        var dPattern = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.DISK_READ : /^disk\/(nvme\d+n\d+|sd[a-z]+)\/read$/;
-        var dIds = discovery.queryIds(dPattern);
-        var seenDisks = {};
+        var disks = discovery.discoveredDisks || [];
         var diskItems = [
             { id: "disk/usage", label: i18n("Overall Usage (%)"), icon: "storage-symbolic" },
             { id: "disk/space", label: i18n("Overall Space"), icon: "storage-symbolic" }
         ];
-        for (var di = 0; di < dIds.length; di++) {
-            var dm = dIds[di].match(dPattern);
-            if (dm && !seenDisks[dm[1]]) {
-                seenDisks[dm[1]] = true;
-                var did = dm[1];
-                var dName = did.indexOf("nvme") !== -1 ? "NVMe" : did;
-                diskItems.push({ id: "disk:" + did + "/read", label: dName + " Read", icon: "network-download-symbolic" });
-                diskItems.push({ id: "disk:" + did + "/write", label: dName + " Write", icon: "network-upload-symbolic" });
-                diskItems.push({ id: "disk:" + did + "/temp", label: dName + " Temp", icon: "temperature-symbolic" });
-            }
+        for (var di = 0; di < disks.length; di++) {
+            var did = disks[di].id;
+            var dName = did.indexOf("nvme") !== -1 ? "NVMe" : did;
+            diskItems.push({ id: "disk:" + did + "/read", label: dName + " Read", icon: "network-download-symbolic" });
+            diskItems.push({ id: "disk:" + did + "/write", label: dName + " Write", icon: "network-upload-symbolic" });
+            diskItems.push({ id: "disk:" + did + "/temp", label: dName + " Temp", icon: "temperature-symbolic" });
         }
         if (diskItems.length > 0) {
             cats.push({
@@ -270,12 +289,11 @@ KCM.SimpleKCM {
         }
 
         // 8. Cooling (Fans)
-        var fPattern = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.FAN : /^(lmsensors|cpu|gpu)\/.*\/fan\d+$/i;
-        var fIds = discovery.queryIds(fPattern);
-        if (fIds.length > 0) {
+        var fans = discovery.discoveredFans || [];
+        if (fans.length > 0) {
             var fanItems = [];
-            for (var fi = 0; fi < fIds.length; fi++) {
-                fanItems.push({ id: "fan:" + fIds[fi] + "/speed", label: i18n("Fan %1 Speed", (fi + 1)), icon: "fan-symbolic" });
+            for (var fi = 0; fi < fans.length; fi++) {
+                fanItems.push({ id: "fan:" + fans[fi].id + "/speed", label: i18n("Fan %1 Speed", (fi + 1)), icon: "fan-symbolic" });
             }
             cats.push({
                 title: i18n("Cooling (Fans)"),

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -80,6 +80,7 @@ PlasmoidItem {
 
             CpuSensors {
                 id: _cpu
+                discovery: _discovery
                 updateInterval: metricConfig.updateInterval
             }
 

--- a/contents/ui/models/HardwareDiscovery.qml
+++ b/contents/ui/models/HardwareDiscovery.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import org.kde.ksysguard.sensors as Sensors
 import org.kde.kitemmodels as KItemModels
+import "./MetricDefinitions.js" as MetricDefinitions
 
 Item {
     id: root
@@ -9,8 +10,24 @@ Item {
     readonly property int revision: _revision
     readonly property var allSensorIds: _allIds
 
+    // Pre-indexed hardware properties
+    readonly property var discoveredGpus: _gpus
+    readonly property var discoveredDisks: _disks
+    readonly property var discoveredFans: _fans
+    readonly property var discoveredCores: _cpuCores
+    readonly property var discoveredNetworkIfaces: _netIfaces
+    readonly property var discoveredBatteries: _batteries
+    readonly property var discoveredDiskTemps: _diskTemps
+
+    // Query cache for O(1) repeated pattern queries
+    property var _patternCache: ({})
+
     function queryIds(pattern) {
         if (!pattern) return [];
+        var key = (pattern instanceof RegExp) ? pattern.source : String(pattern);
+        if (_patternCache[key]) {
+            return _patternCache[key];
+        }
         var regex = (pattern instanceof RegExp) ? pattern : new RegExp(pattern);
         var result = [];
         for (var i = 0; i < _allIds.length; i++) {
@@ -18,11 +35,16 @@ Item {
                 result.push(_allIds[i]);
             }
         }
+        _patternCache[key] = result;
         return result;
     }
 
     function query(pattern) {
         if (!pattern) return [];
+        var key = "full_" + ((pattern instanceof RegExp) ? pattern.source : String(pattern));
+        if (_patternCache[key]) {
+            return _patternCache[key];
+        }
         var regex = (pattern instanceof RegExp) ? pattern : new RegExp(pattern);
         var result = [];
         for (var i = 0; i < _allSensors.length; i++) {
@@ -30,6 +52,7 @@ Item {
                 result.push(_allSensors[i]);
             }
         }
+        _patternCache[key] = result;
         return result;
     }
 
@@ -37,11 +60,23 @@ Item {
         return _idSet[sensorId] === true;
     }
 
+    function rescan() {
+        _rebuildInventory();
+    }
+
     property var _allIds: []
     property var _allSensors: []
     property var _idSet: ({})
     property int _revision: 0
     property bool _dirty: false
+
+    property var _gpus: []
+    property var _disks: []
+    property var _fans: []
+    property var _cpuCores: []
+    property var _netIfaces: ["auto"]
+    property var _batteries: []
+    property var _diskTemps: []
 
     Sensors.SensorTreeModel {
         id: sensorTree
@@ -65,10 +100,16 @@ Item {
 
     Connections {
         target: flatSensors
-        function onRowsInserted() { root._dirty = true; }
-        function onRowsRemoved()  { root._dirty = true; }
-        function onModelReset()   { root._dirty = true; }
-        function onDataChanged()  { root._dirty = true; }
+        function onRowsInserted() {
+            if (root._allIds.length === 0) {
+                root._rebuildInventory();
+            } else {
+                root._dirty = true;
+            }
+        }
+        function onRowsRemoved() { root._dirty = true; }
+        function onModelReset() { root._rebuildInventory(); }
+        function onDataChanged() { root._dirty = true; }
     }
 
     function _rebuildInventory() {
@@ -76,6 +117,22 @@ Item {
         var ids = [];
         var sensors = [];
         var set = {};
+
+        var gpuMap = {};
+        var diskMap = {};
+        var fanSet = {};
+        var coreMap = {};
+        var ifaceSet = {};
+        var batSet = {};
+        var diskTempSet = {};
+
+        var pGpu = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.GPU : /^gpu\/(gpu\d+)\/usage$/;
+        var pDisk = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.DISK_READ : /^disk\/(nvme\d+n\d+|sd[a-z]+)\/read$/;
+        var pFan = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.FAN : /^(lmsensors|cpu|gpu)\/.*\/fan\d+$/i;
+        var pCore = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.CPU_CORE : /^cpu\/(cpu\d+)\/usage$/;
+        var pNet = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.NETWORK_IFACE : /^network\/([^/]+)\/download$/;
+        var pBat = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.BATTERY : /^power\/((?:battery_)[a-zA-Z0-9_-]+|BAT\d+|BATT\d*)\/chargePercentage$/;
+        var pDiskTemp = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.DISK_TEMP : /^lmsensors\/(nvme-pci-[^/]+|drivetemp-scsi-[^/]+)\/temp[12]$/;
 
         for (var row = 0; row < rowCount; row++) {
             var idx = flatSensors.index(row, 0);
@@ -87,11 +144,54 @@ Item {
             ids.push(sid);
             sensors.push({ id: sid, name: name });
             set[sid] = true;
+
+            var m = null;
+            if ((m = sid.match(pGpu))) {
+                gpuMap[m[1]] = true;
+            } else if ((m = sid.match(pDisk))) {
+                diskMap[m[1]] = true;
+            } else if (pFan.test(sid)) {
+                fanSet[sid] = true;
+            } else if ((m = sid.match(pCore))) {
+                coreMap[m[1]] = true;
+            } else if ((m = sid.match(pNet))) {
+                if (m[1] !== "all" && m[1] !== "lo") ifaceSet[m[1]] = true;
+            } else if ((m = sid.match(pBat))) {
+                batSet[m[1]] = true;
+            } else if (pDiskTemp.test(sid)) {
+                diskTempSet[sid] = true;
+            }
         }
 
         _allIds = ids;
         _allSensors = sensors;
         _idSet = set;
+        _patternCache = {};
+
+        var gList = Object.keys(gpuMap).sort();
+        _gpus = gList.map(function(id, i) { return { id: id, name: "GPU " + (i + 1) }; });
+
+        var dList = Object.keys(diskMap).sort();
+        _disks = dList.map(function(id, i) { return { id: id, name: "Disk " + (i + 1) }; });
+
+        var fList = Object.keys(fanSet).sort();
+        _fans = fList.map(function(id, i) { return { id: id, name: "Fan " + (i + 1) }; });
+
+        var cList = Object.keys(coreMap);
+        var cSorted = [];
+        for (var ci = 0; ci < cList.length; ci++) {
+            var num = parseInt(cList[ci].replace("cpu", ""), 10);
+            cSorted.push({ id: cList[ci], number: isNaN(num) ? ci : num });
+        }
+        cSorted.sort(function(a, b) { return a.number - b.number; });
+        _cpuCores = cSorted.map(function(c) { return { id: c.id, number: c.number, name: "Core " + (c.number + 1) }; });
+
+        var nList = Object.keys(ifaceSet).sort();
+        _netIfaces = ["auto"].concat(nList);
+
+        _batteries = Object.keys(batSet).sort();
+        _diskTemps = Object.keys(diskTempSet).sort();
+
         _revision++;
     }
 

--- a/contents/ui/models/MetricDefinitions.js
+++ b/contents/ui/models/MetricDefinitions.js
@@ -16,7 +16,8 @@ var GROUPS = {
             { key: "temp",   label: "Temperature" },
             { key: "load1",  label: "Load (1m)" },
             { key: "load5",  label: "Load (5m)" },
-            { key: "load15", label: "Load (15m)" }
+            { key: "load15", label: "Load (15m)" },
+            { key: "core",   label: "Cores" }
         ]
     },
     ram: {
@@ -85,9 +86,12 @@ var GROUPS = {
         defaultIcon: "network-symbolic",
         defaultSubMetrics: "down,up",
         subs: [
-            { key: "down", label: "Download" },
-            { key: "up",   label: "Upload" },
-            { key: "ip",   label: "IP address" }
+            { key: "down",      label: "Download" },
+            { key: "up",        label: "Upload" },
+            { key: "totalDown", label: "Total Downloaded" },
+            { key: "totalUp",   label: "Total Uploaded" },
+            { key: "signal",    label: "Wi-Fi Signal" },
+            { key: "ip",        label: "IP address" }
         ]
     },
     disk: {
@@ -130,6 +134,7 @@ var ALL_GROUP_KEYS = ["cpu", "ram", "swap", "temp", "gpu", "bat", "net", "disk",
 
 // Canonical discovery patterns for dynamic hardware devices
 var PATTERNS = {
+    CPU_CORE: /^cpu\/(cpu\d+)\/usage$/,
     GPU: /^gpu\/(gpu\d+)\/usage$/,
     DISK_READ: /^disk\/(nvme\d+n\d+|sd[a-z]+)\/read$/,
     DISK_TEMP: /^lmsensors\/(nvme-pci-[^/]+|drivetemp-scsi-[^/]+)\/temp[12]$/,
@@ -208,6 +213,15 @@ var DEFINITIONS = {
         sensorId: "cpu/loadaverages/loadaverage15",
         label: "Load (15m)",
         thresholdType: "none"
+    },
+    "cpu.core": {
+        id: "cpu.core",
+        group: "cpu",
+        subKey: "core",
+        sensorPattern: "cpu/{id}/usage",
+        label: "Core Usage",
+        thresholdType: "normal",
+        thresholdKey: "cpu"
     },
     "ram.percentage": {
         id: "ram.percentage",
@@ -373,6 +387,34 @@ var DEFINITIONS = {
         sensorPattern: "network/{id}/ipv4withPrefixLength",
         label: "Local IP",
         icon: "network-symbolic",
+        thresholdType: "none"
+    },
+    "net.signal": {
+        id: "net.signal",
+        group: "net",
+        subKey: "signal",
+        sensorPattern: "network/{id}/signal",
+        label: "Wi-Fi Signal",
+        icon: "network-wireless-symbolic",
+        thresholdType: "inverted",
+        thresholdKey: "battery"
+    },
+    "net.totalDown": {
+        id: "net.totalDown",
+        group: "net",
+        subKey: "totalDown",
+        sensorPattern: "network/{id}/totalDownload",
+        label: "Total Downloaded",
+        icon: "network-download-symbolic",
+        thresholdType: "none"
+    },
+    "net.totalUp": {
+        id: "net.totalUp",
+        group: "net",
+        subKey: "totalUp",
+        sensorPattern: "network/{id}/totalUpload",
+        label: "Total Uploaded",
+        icon: "network-upload-symbolic",
         thresholdType: "none"
     },
     "disk.read": {

--- a/contents/ui/models/MetricStore.qml
+++ b/contents/ui/models/MetricStore.qml
@@ -189,6 +189,23 @@ Item {
                     status: !isNaN(s.temp.cpuTempNumericValue) ? "ready" : "unavailable"
                 }));
             }
+
+            if (s.cpu.coreDataList && s.cpu.coreDataList.length > 0) {
+                var cList = s.cpu.coreDataList;
+                for (var ci = 0; ci < cList.length; ci++) {
+                    var cd = cList[ci];
+                    list.push(_createMetric("cpu.core", {
+                        deviceId: cd.id,
+                        deviceName: cd.name,
+                        label: cd.name,
+                        groupLabel: cfg.cpuLabel,
+                        subLabel: cd.name,
+                        value: cd.usageNumber,
+                        displayValue: cd.usage,
+                        status: !isNaN(cd.usageNumber) ? "ready" : "loading"
+                    }));
+                }
+            }
         }
 
         // RAM
@@ -368,6 +385,36 @@ Item {
                 icon: cfg.resolveIcon("network-upload-symbolic"),
                 status: !isNaN(s.network.netUpRaw) ? "ready" : "loading"
             }));
+            if (s.network.netTotalDownValue && s.network.netTotalDownValue !== "..." && !isNaN(s.network.netTotalDownRaw)) {
+                list.push(_createMetric("net.totalDown", {
+                    value: s.network.netTotalDownRaw,
+                    displayValue: s.network.netTotalDownValue,
+                    label: cfg.netLabel + " Total ↓",
+                    subLabel: "Total Downloaded",
+                    icon: cfg.resolveIcon("network-download-symbolic"),
+                    status: "ready"
+                }));
+            }
+            if (s.network.netTotalUpValue && s.network.netTotalUpValue !== "..." && !isNaN(s.network.netTotalUpRaw)) {
+                list.push(_createMetric("net.totalUp", {
+                    value: s.network.netTotalUpRaw,
+                    displayValue: s.network.netTotalUpValue,
+                    label: cfg.netLabel + " Total ↑",
+                    subLabel: "Total Uploaded",
+                    icon: cfg.resolveIcon("network-upload-symbolic"),
+                    status: "ready"
+                }));
+            }
+            if (s.network.hasWifiSignal && !isNaN(s.network.netSignalRaw)) {
+                list.push(_createMetric("net.signal", {
+                    value: s.network.netSignalRaw,
+                    displayValue: s.network.netSignalValue,
+                    label: cfg.netLabel + " Signal",
+                    subLabel: "Wi-Fi Signal",
+                    icon: cfg.resolveIcon("network-wireless-symbolic"),
+                    status: "ready"
+                }));
+            }
             if (s.network.netIpValue && s.network.netIpValue !== "..." && s.network.netIpValue !== "") {
                 list.push(_createMetric("net.ip", {
                     displayValue: s.network.netIpValue,

--- a/contents/ui/models/ViewHelpers.js
+++ b/contents/ui/models/ViewHelpers.js
@@ -85,18 +85,24 @@ function buildPopupGroups(metricsList, orderedKeys) {
     var cpuMetrics = available.filter(function(m) { return m.group === "cpu" && m.subKey !== "temp"; });
     if (cpuMetrics.length > 0) {
         var cpuUsage = map["cpu/usage"] || cpuMetrics[0];
+        var coreMetrics = cpuMetrics.filter(function(m) { return m.subKey === "core"; });
+        var nonCoreMetrics = cpuMetrics.filter(function(m) { return m.subKey !== "core"; });
+
+        var cpuSections = [];
+        if (coreMetrics.length > 0 && nonCoreMetrics.length > 0) {
+            cpuSections.push({ sectionLabel: "", metrics: nonCoreMetrics });
+            cpuSections.push({ sectionLabel: "Cores", metrics: coreMetrics });
+        } else {
+            cpuSections.push({ sectionLabel: "", metrics: cpuMetrics });
+        }
+
         categories.push({
             key: "processor",
             groupLabel: "Processor",
             icon: "cpu-symbolic",
             aggregateValue: cpuUsage ? cpuUsage.displayValue : "",
             aggregateColor: cpuUsage ? cpuUsage.color : "",
-            sections: [
-                {
-                    sectionLabel: "",
-                    metrics: cpuMetrics
-                }
-            ]
+            sections: cpuSections
         });
     }
 
@@ -244,7 +250,7 @@ function buildPopupGroups(metricsList, orderedKeys) {
 }
 
 function _resolveSegmentLabel(metric, isTemp) {
-    if (isTemp || metric.group === "fan") return metric.subLabel || "";
+    if (isTemp || metric.group === "fan" || metric.subKey === "core") return metric.subLabel || "";
     // For CPU, RAM, Swap, Battery, GPU, Network, Disk, value or icon is self-describing
     return "";
 }

--- a/contents/ui/sensors/CpuSensors.qml
+++ b/contents/ui/sensors/CpuSensors.qml
@@ -1,9 +1,11 @@
 import QtQuick
 import org.kde.ksysguard.sensors as Sensors
+import "../models/MetricDefinitions.js" as MetricDefinitions
 
 Item {
     id: root
 
+    property var discovery: null
     property int updateInterval: 2000
 
     readonly property real cpuNumericValue: {
@@ -18,7 +20,7 @@ Item {
         return Math.round(cpuNumericValue).toString().padStart(3) + "%";
     }
 
-    // Frequency in MHz from KSysGuard (unit type 302 = MHz); displays as GHz above 1000 MHz
+    // Frequency in MHz from KSysGuard
     readonly property string cpuFreqValue: {
         if (freqSensor.status !== Sensors.Sensor.Ready || freqSensor.value == null)
             return "...";
@@ -64,5 +66,67 @@ Item {
         id: load15Sensor
         sensorId: "cpu/loadaverages/loadaverage15"
         updateRateLimit: root.updateInterval
+    }
+
+    // CPU core discovery
+    readonly property var discoveredCores: _discoveredCores
+    property var _discoveredCores: []
+
+    readonly property var coreDataList: _dataList
+    property var _dataList: []
+
+    function refreshDiscovered() {
+        if (!discovery) return;
+        var found = discovery.discoveredCores || [];
+        if (JSON.stringify(found) !== JSON.stringify(_discoveredCores)) {
+            _discoveredCores = found;
+            aggregateCores();
+        }
+    }
+
+    Connections {
+        target: discovery
+        function onRevisionChanged() { root.refreshDiscovered(); }
+    }
+
+    onDiscoveryChanged: refreshDiscovered()
+    Component.onCompleted: refreshDiscovered()
+
+    readonly property var _activeSensorIds: _discoveredCores.map(function(c){ return "cpu/" + c.id + "/usage"; })
+
+    Sensors.SensorDataModel {
+        id: coreData
+        sensors: root._activeSensorIds
+        updateRateLimit: root.updateInterval
+        enabled: root._activeSensorIds.length > 0
+        onDataChanged: root.aggregateCores()
+        onReadyChanged: { if (ready) root.aggregateCores(); }
+    }
+
+    function _modelValue(sensorId) {
+        var col = coreData.column(sensorId);
+        if (col < 0) return NaN;
+        var idx = coreData.index(0, col);
+        if (!idx.valid) return NaN;
+        var val = coreData.data(idx, Sensors.SensorDataModel.Value);
+        return (val === undefined || val === null) ? NaN : val;
+    }
+
+    function aggregateCores() {
+        var newList = [];
+        for (var i = 0; i < _discoveredCores.length; i++) {
+            var c = _discoveredCores[i];
+            var val = _modelValue("cpu/" + c.id + "/usage");
+            var num = (typeof val === "number" && !isNaN(val)) ? val : NaN;
+            var str = !isNaN(num) ? Math.round(num).toString().padStart(3) + "%" : "...";
+            newList.push({
+                id: c.id,
+                name: c.name,
+                number: c.number,
+                usageNumber: num,
+                usage: str
+            });
+        }
+        _dataList = newList;
     }
 }

--- a/contents/ui/sensors/DiskSensors.qml
+++ b/contents/ui/sensors/DiskSensors.qml
@@ -94,15 +94,11 @@ Item {
 
     function refreshDiscovered() {
         if (!discovery) return;
+        var disks = discovery.discoveredDisks || [];
         var found = [];
-        var pattern = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.DISK_READ : /^disk\/(nvme\d+n\d+|sd[a-z]+)\/read$/;
-        var ids = discovery.queryIds(pattern);
-        for (var i = 0; i < ids.length; i++) {
-            var match = ids[i].match(pattern);
-            if (!match) continue;
-            var did = match[1];
+        for (var i = 0; i < disks.length; i++) {
+            var did = disks[i].id;
             if (_unplugged[did]) continue;
-            if (found.some(function(d){ return d.id === did; })) continue;
             found.push({ id: did, name: "DSK " + (found.length + 1) });
         }
         if (JSON.stringify(found) !== JSON.stringify(_discovered)) {

--- a/contents/ui/sensors/FanSensors.qml
+++ b/contents/ui/sensors/FanSensors.qml
@@ -29,11 +29,9 @@ Item {
 
     function refreshDiscovered() {
         if (!discovery) return;
-        var pattern = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.FAN : /^(lmsensors|cpu|gpu)\/.*\/fan\d+$/i;
-        var ids = discovery.queryIds(pattern);
-        ids.sort();
-        var found = ids.map(function(id, i) {
-            return { id: id, name: "Fan " + (i + 1), number: i + 1 };
+        var fans = discovery.discoveredFans || [];
+        var found = fans.map(function(f, i) {
+            return { id: f.id, name: f.name, number: i + 1 };
         });
 
         if (JSON.stringify(found) !== JSON.stringify(_discovered)) {

--- a/contents/ui/sensors/GpuSensors.qml
+++ b/contents/ui/sensors/GpuSensors.qml
@@ -98,15 +98,7 @@ Item {
 
     function refreshDiscovered() {
         if (!discovery) return;
-        var found = [];
-        var pattern = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.GPU : /^gpu\/(gpu\d+)\/usage$/;
-        var ids = discovery.queryIds(pattern);
-        for (var i = 0; i < ids.length; i++) {
-            var match = ids[i].match(pattern);
-            if (!match) continue;
-            found.push({ id: match[1], name: "GPU " + (found.length + 1) });
-        }
-
+        var found = discovery.discoveredGpus || [];
         if (JSON.stringify(found) !== JSON.stringify(_discovered)) {
             _discovered = found;
         }

--- a/contents/ui/sensors/NetworkSensors.qml
+++ b/contents/ui/sensors/NetworkSensors.qml
@@ -41,18 +41,11 @@ Item {
 
     function _refreshInterfaces() {
         if (!discovery) return;
-        var found = [];
-        var pattern = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.NETWORK_IFACE : /^network\/([^/]+)\/download$/;
-        var ids = discovery.queryIds(pattern);
-        for (var i = 0; i < ids.length; i++) {
-            var match = ids[i].match(pattern);
-            if (!match) continue;
-            var iface = match[1];
-            if (iface === "all" || iface === "lo") continue;
-            if (found.indexOf(iface) < 0) found.push(iface);
-        }
-        if (JSON.stringify(found) !== JSON.stringify(_discoveredIfaces))
-            _discoveredIfaces = found;
+        var ifaces = (discovery.discoveredNetworkIfaces || []).filter(function(iface) {
+            return iface !== "auto";
+        });
+        if (JSON.stringify(ifaces) !== JSON.stringify(_discoveredIfaces))
+            _discoveredIfaces = ifaces;
     }
 
     Connections {
@@ -145,6 +138,25 @@ Item {
         updateRateLimit: root.updateInterval
     }
 
+    // Cumulative totals sensors
+    readonly property real netTotalDownRaw: (netTotalDownSensor.status === Sensors.Sensor.Ready && netTotalDownSensor.value != null) ? Number(netTotalDownSensor.value) : NaN
+    readonly property real netTotalUpRaw:   (netTotalUpSensor.status   === Sensors.Sensor.Ready && netTotalUpSensor.value != null)   ? Number(netTotalUpSensor.value)   : NaN
+
+    readonly property string netTotalDownValue: isNaN(netTotalDownRaw) ? "..." : Utils.formatData(netTotalDownRaw)
+    readonly property string netTotalUpValue:   isNaN(netTotalUpRaw)   ? "..." : Utils.formatData(netTotalUpRaw)
+
+    Sensors.Sensor {
+        id: netTotalDownSensor
+        sensorId: "network/" + root.netIfacePath + "/totalDownload"
+        updateRateLimit: root.updateInterval
+    }
+
+    Sensors.Sensor {
+        id: netTotalUpSensor
+        sensorId: "network/" + root.netIfacePath + "/totalUpload"
+        updateRateLimit: root.updateInterval
+    }
+
     // IP address sensor
 
     readonly property string netIpValue: {
@@ -162,5 +174,23 @@ Item {
                   ? "network/" + root.netIpIfacePath + "/ipv4withPrefixLength"
                   : ""
         updateRateLimit: root.updateInterval
+    }
+
+    // Wi-Fi signal sensor
+    readonly property string netSignalSensorId: {
+        if (netIpIfacePath === "") return "";
+        if (discovery && !discovery.sensorExists("network/" + netIpIfacePath + "/signal")) return "";
+        return "network/" + netIpIfacePath + "/signal";
+    }
+
+    readonly property real netSignalRaw: (netSignalSensor.status === Sensors.Sensor.Ready && netSignalSensor.value != null) ? Number(netSignalSensor.value) : NaN
+    readonly property string netSignalValue: isNaN(netSignalRaw) ? "" : Math.round(netSignalRaw) + "%"
+    readonly property bool hasWifiSignal: netSignalSensorId !== "" && !isNaN(netSignalRaw)
+
+    Sensors.Sensor {
+        id: netSignalSensor
+        sensorId: root.netSignalSensorId
+        updateRateLimit: root.updateInterval
+        enabled: root.netSignalSensorId !== ""
     }
 }

--- a/contents/ui/sensors/NetworkSensors.qml
+++ b/contents/ui/sensors/NetworkSensors.qml
@@ -176,13 +176,30 @@ Item {
         updateRateLimit: root.updateInterval
     }
 
-    // Wi-Fi signal sensor
-    readonly property string netSignalSensorId: {
-        if (netIpIfacePath === "") return "";
-        if (discovery && !discovery.sensorExists("network/" + netIpIfacePath + "/signal")) return "";
-        return "network/" + netIpIfacePath + "/signal";
+    // Wi-Fi interface resolution
+    readonly property string _wifiIface: {
+        if (networkInterface !== "" && networkInterface !== "auto") {
+            if (discovery && discovery.sensorExists("network/" + networkInterface + "/signal")) {
+                return networkInterface;
+            }
+            return "";
+        }
+        if (_activeIface !== "" && discovery && discovery.sensorExists("network/" + _activeIface + "/signal")) {
+            return _activeIface;
+        }
+        if (discovery) {
+            for (var i = 0; i < _discoveredIfaces.length; i++) {
+                var iface = _discoveredIfaces[i];
+                if (discovery.sensorExists("network/" + iface + "/signal")) {
+                    return iface;
+                }
+            }
+        }
+        return "";
     }
 
+    // Wi-Fi signal sensor
+    readonly property string netSignalSensorId: _wifiIface !== "" ? "network/" + _wifiIface + "/signal" : ""
     readonly property real netSignalRaw: (netSignalSensor.status === Sensors.Sensor.Ready && netSignalSensor.value != null) ? Number(netSignalSensor.value) : NaN
     readonly property string netSignalValue: isNaN(netSignalRaw) ? "" : Math.round(netSignalRaw) + "%"
     readonly property bool hasWifiSignal: netSignalSensorId !== "" && !isNaN(netSignalRaw)

--- a/contents/ui/sensors/Utils.qml
+++ b/contents/ui/sensors/Utils.qml
@@ -10,6 +10,18 @@ QtObject {
         return gb.toFixed(1);
     }
 
+    function formatData(bytes) {
+        if (typeof bytes !== "number" || isNaN(bytes) || bytes < 0)
+            return "...";
+        if (bytes < 1024 * 1024)
+            return (bytes / 1024).toFixed(1) + " KB";
+        if (bytes < 1024 * 1024 * 1024)
+            return (bytes / (1024 * 1024)).toFixed(1) + " MB";
+        if (bytes < 1024 * 1024 * 1024 * 1024)
+            return (bytes / (1024 * 1024 * 1024)).toFixed(2) + " GB";
+        return (bytes / (1024 * 1024 * 1024 * 1024)).toFixed(2) + " TB";
+    }
+
     // unit: "bytes" (default, KB/MB) or "bits" (Kb/Mb)
     // Always uses 3 significant figures, padded to 6 chars for stable display
     function formatRate(bytesPerSec, unit) {


### PR DESCRIPTION

## Description

This pull request refactors and streamlines hardware metric discovery and UI layout in the configuration QML files. The main improvements include centralizing hardware discovery logic, simplifying and unifying the UI structure, and enhancing the configuration panel's flexibility and maintainability.

**Hardware Discovery Refactoring:**

* Replaces inline hardware discovery (for GPUs, disks, fans, and network interfaces) in `configMetrics.qml` with direct bindings to properties (`discoveredGpus`, `discoveredDisks`, `discoveredFans`, `ifaceList`) provided by the `discovery` object, centralizing and optimizing hardware detection logic.
* Removes the use of `Plasma5Support.DataSource` for network interface discovery, now relying on the new `discovery.discoveredNetworkIfaces` property.
* Adds import of `MetricDefinitions.js` to `HardwareDiscovery.qml` to support pattern matching in hardware detection.

**UI Structure and Maintainability:**

* Refactors the metric configuration UI to use a `ColumnLayout` containing multiple `Kirigami.FormLayout` sections, each with a unique `id` and properly grouped, improving maintainability and visual consistency. [[1]](diffhunk://#diff-76cb999476b1b28c00991fd602813bb21ec4e7de6b695410d2b28bd2e3293574L124-R102) [[2]](diffhunk://#diff-76cb999476b1b28c00991fd602813bb21ec4e7de6b695410d2b28bd2e3293574R116-R122) [[3]](diffhunk://#diff-76cb999476b1b28c00991fd602813bb21ec4e7de6b695410d2b28bd2e3293574R144-R150) [[4]](diffhunk://#diff-76cb999476b1b28c00991fd602813bb21ec4e7de6b695410d2b28bd2e3293574R164-R170) [[5]](diffhunk://#diff-76cb999476b1b28c00991fd602813bb21ec4e7de6b695410d2b28bd2e3293574R218-R224) [[6]](diffhunk://#diff-76cb999476b1b28c00991fd602813bb21ec4e7de6b695410d2b28bd2e3293574R257-R263) [[7]](diffhunk://#diff-76cb999476b1b28c00991fd602813bb21ec4e7de6b695410d2b28bd2e3293574R289-R295) [[8]](diffhunk://#diff-76cb999476b1b28c00991fd602813bb21ec4e7de6b695410d2b28bd2e3293574R322-R328) [[9]](diffhunk://#diff-76cb999476b1b28c00991fd602813bb21ec4e7de6b695410d2b28bd2e3293574L351-L363) [[10]](diffhunk://#diff-76cb999476b1b28c00991fd602813bb21ec4e7de6b695410d2b28bd2e3293574R360-R373)

**Configuration Panel Logic Improvements:**

* Updates the configuration panel (`configPanelOrder.qml`) to use the new hardware discovery properties (`discoveredCores`, `discoveredGpus`, `discoveredDisks`, `discoveredFans`) for dynamic item generation, enabling more accurate and flexible panel customization (e.g., per-core CPU, per-GPU, per-disk, and per-fan metrics). [[1]](diffhunk://#diff-4843c403a904592360e084e99b5561e882cb4deadf743d108f50e20a934ba5d2L165-R197) [[2]](diffhunk://#diff-4843c403a904592360e084e99b5561e882cb4deadf743d108f50e20a934ba5d2L211-L237) [[3]](diffhunk://#diff-4843c403a904592360e084e99b5561e882cb4deadf743d108f50e20a934ba5d2L246-L263) [[4]](diffhunk://#diff-4843c403a904592360e084e99b5561e882cb4deadf743d108f50e20a934ba5d2L273-R296)
* Adds preview values and icons for new network metrics (Wi-Fi signal, total upload/download) and improves per-core CPU display names in the panel preview. [[1]](diffhunk://#diff-4843c403a904592360e084e99b5561e882cb4deadf743d108f50e20a934ba5d2R127-R133) [[2]](diffhunk://#diff-4843c403a904592360e084e99b5561e882cb4deadf743d108f50e20a934ba5d2R143-R154)

**Code Cleanup:**

* Removes the unused import of `Plasma5Support` from `configMetrics.qml`.
* Passes the `discovery` object to `CpuSensors` in `main.qml` to ensure it has access to centralized hardware data.
