### PR TITLE
fix: resolve battery detection for serial IDs and normalize selection(fix #97)

### DIFF
--- a/contents/ui/configMetrics.qml
+++ b/contents/ui/configMetrics.qml
@@ -63,6 +63,13 @@ KCM.SimpleKCM {
     readonly property var discoveredDisks: discovery.discoveredDisks
     readonly property var discoveredFans: discovery.discoveredFans
     readonly property var ifaceList: discovery.discoveredNetworkIfaces
+    readonly property var batteryList: {
+        var list = ["auto"].concat(discovery.discoveredBatteries || []);
+        if (cfg_batteryDevice && list.indexOf(cfg_batteryDevice) === -1) {
+            list.push(cfg_batteryDevice);
+        }
+        return list;
+    }
 
     // Fan max-RPM check
     property bool fanMaxFallbackNeeded: true
@@ -240,18 +247,19 @@ KCM.SimpleKCM {
                 Kirigami.FormData.label: i18n("Battery device:")
                 spacing: Kirigami.Units.smallSpacing
 
-                TextField {
-                    text: cfg_batteryDevice === "auto" ? "" : cfg_batteryDevice
-                    placeholderText: i18n("Auto-detect (e.g. BAT0)")
-                    implicitWidth: Kirigami.Units.gridUnit * 14
-                    onTextEdited: {
-                        var v = text.trim();
-                        cfg_batteryDevice = v.length > 0 ? v : "auto";
+                ComboBox {
+                    id: batDeviceCombo
+                    model: metricsPage.batteryList
+                    currentIndex: {
+                        var idx = metricsPage.batteryList.indexOf(cfg_batteryDevice);
+                        return idx >= 0 ? idx : 0;
                     }
+                    onActivated: cfg_batteryDevice = metricsPage.batteryList[currentIndex]
+                    implicitWidth: Kirigami.Units.gridUnit * 14
                 }
 
                 Kirigami.ContextualHelpButton {
-                    toolTipText: i18n("Leave empty for automatic detection. Specify a custom sysfs battery device name (e.g. BAT0, BAT1) if multiple batteries are installed.")
+                    toolTipText: i18n("Select 'auto' for automatic detection, or select a specific battery if multiple are installed.")
                 }
             }
         }

--- a/contents/ui/models/HardwareDiscovery.qml
+++ b/contents/ui/models/HardwareDiscovery.qml
@@ -131,7 +131,7 @@ Item {
         var pFan = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.FAN : /^(lmsensors|cpu|gpu)\/.*\/fan\d+$/i;
         var pCore = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.CPU_CORE : /^cpu\/(cpu\d+)\/usage$/;
         var pNet = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.NETWORK_IFACE : /^network\/([^/]+)\/download$/;
-        var pBat = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.BATTERY : /^power\/((?!all)[^/]+)\/chargePercentage$/;
+        var pBat = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.BATTERY : /^power\/([^/]+)\/chargePercentage$/;
         var pDiskTemp = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.DISK_TEMP : /^(?:disk\/(?:nvme\d+n\d+|sd[a-z]+)\/temperature|lmsensors\/(?:nvme-pci-[^/]+|drivetemp-scsi-[^/]+|scsi-[^/]+|drivetemp-[^/]+)\/temp\d+)$/;
 
         for (var row = 0; row < rowCount; row++) {

--- a/contents/ui/models/HardwareDiscovery.qml
+++ b/contents/ui/models/HardwareDiscovery.qml
@@ -131,7 +131,7 @@ Item {
         var pFan = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.FAN : /^(lmsensors|cpu|gpu)\/.*\/fan\d+$/i;
         var pCore = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.CPU_CORE : /^cpu\/(cpu\d+)\/usage$/;
         var pNet = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.NETWORK_IFACE : /^network\/([^/]+)\/download$/;
-        var pBat = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.BATTERY : /^power\/((?:battery_)[a-zA-Z0-9_-]+|BAT\d+|BATT\d*)\/chargePercentage$/;
+        var pBat = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.BATTERY : /^power\/((?!all)[^/]+)\/chargePercentage$/;
         var pDiskTemp = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.DISK_TEMP : /^(?:disk\/(?:nvme\d+n\d+|sd[a-z]+)\/temperature|lmsensors\/(?:nvme-pci-[^/]+|drivetemp-scsi-[^/]+|scsi-[^/]+|drivetemp-[^/]+)\/temp\d+)$/;
 
         for (var row = 0; row < rowCount; row++) {

--- a/contents/ui/models/MetricDefinitions.js
+++ b/contents/ui/models/MetricDefinitions.js
@@ -160,7 +160,7 @@ var PATTERNS = {
     FAN: /^(lmsensors|cpu|gpu)\/.*\/fan\d+$/i,
     NETWORK_IFACE: /^network\/([^/]+)\/download$/,
     TEMP_LMSENSORS: /^lmsensors\/(.+)\/temp\d+$/,
-    BATTERY: /^power\/((?!all)[^/]+)\/chargePercentage$/
+    BATTERY: /^power\/([^/]+)\/chargePercentage$/
 };
 
 // DEFINITIONS is the source of truth for every metric.

--- a/contents/ui/models/MetricDefinitions.js
+++ b/contents/ui/models/MetricDefinitions.js
@@ -160,7 +160,7 @@ var PATTERNS = {
     FAN: /^(lmsensors|cpu|gpu)\/.*\/fan\d+$/i,
     NETWORK_IFACE: /^network\/([^/]+)\/download$/,
     TEMP_LMSENSORS: /^lmsensors\/(.+)\/temp\d+$/,
-    BATTERY: /^power\/((?:battery_)[a-zA-Z0-9_-]+|BAT\d+|BATT\d*)\/chargePercentage$/
+    BATTERY: /^power\/((?!all)[^/]+)\/chargePercentage$/
 };
 
 // DEFINITIONS is the source of truth for every metric.

--- a/contents/ui/sensors/BatterySensors.qml
+++ b/contents/ui/sensors/BatterySensors.qml
@@ -14,14 +14,20 @@ Item {
     function refreshDiscovered() {
         if (batteryDevice && batteryDevice !== "auto") return;
         if (!discovery) return;
-        var pattern = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.BATTERY : /^power\/((?:battery_)[a-zA-Z0-9_-]+|BAT\d+|BATT\d*)\/chargePercentage$/;
+        var pattern = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.BATTERY : /^power\/((?!all)[^/]+)\/chargePercentage$/;
         var ids = discovery.queryIds(pattern);
         if (ids.length > 0) {
             var match = ids[0].match(pattern);
             if (match && match[1]) {
                 discoveredBatId = match[1];
+                return;
             }
         }
+        if (discovery.discoveredBatteries && discovery.discoveredBatteries.length > 0) {
+            discoveredBatId = discovery.discoveredBatteries[0];
+            return;
+        }
+        discoveredBatId = "";
     }
 
     Connections {
@@ -33,12 +39,23 @@ Item {
     Component.onCompleted: refreshDiscovered()
 
     readonly property string _resolvedBase: {
+        var _rev = discovery ? discovery.revision : 0;
         if (batteryDevice && batteryDevice !== "auto") {
-            if (batteryDevice.startsWith("battery_") || batteryDevice.startsWith("power/"))
-                return batteryDevice;
-            return "battery_" + batteryDevice;
+            var dev = batteryDevice.trim();
+            dev = dev.replace(/^power\//, "").replace(/\/.*$/, "");
+            if (discovery && discovery.sensorExists) {
+                if (discovery.sensorExists("power/" + dev + "/chargePercentage"))
+                    return dev;
+                if (discovery.sensorExists("power/battery_" + dev + "/chargePercentage"))
+                    return "battery_" + dev;
+                var stripped = dev.replace(/^battery_/, "");
+                if (discovery.sensorExists("power/" + stripped + "/chargePercentage"))
+                    return stripped;
+                return "";
+            }
+            return "";
         }
-        return discoveredBatId || "battery_BAT0";
+        return discoveredBatId;
     }
 
     readonly property string batChargeSensorId: _resolvedBase ? ("power/" + _resolvedBase + "/chargePercentage") : ""
@@ -60,9 +77,10 @@ Item {
     readonly property string batHealthValue: isNaN(batHealthNumericValue) ? "" : Math.round(batHealthNumericValue) + "%"
 
     readonly property bool hasBattery: {
-        if (batteryDevice && batteryDevice !== "auto") return true;
-        if (discoveredBatId && discoveredBatId.length > 0) return true;
+        if (!_resolvedBase || _resolvedBase.length === 0) return false;
         if (batChargeSensor.status === Sensors.Sensor.Ready && !isNaN(batNumericValue)) return true;
+        if (discoveredBatId && discoveredBatId.length > 0) return true;
+        if (batteryDevice && batteryDevice !== "auto") return true;
         return false;
     }
 

--- a/contents/ui/sensors/BatterySensors.qml
+++ b/contents/ui/sensors/BatterySensors.qml
@@ -14,7 +14,7 @@ Item {
     function refreshDiscovered() {
         if (batteryDevice && batteryDevice !== "auto") return;
         if (!discovery) return;
-        var pattern = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.BATTERY : /^power\/((?!all)[^/]+)\/chargePercentage$/;
+        var pattern = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.BATTERY : /^power\/([^/]+)\/chargePercentage$/;
         var ids = discovery.queryIds(pattern);
         if (ids.length > 0) {
             var match = ids[0].match(pattern);


### PR DESCRIPTION
## Description

Resolves an issue where battery metrics fail to display on laptops reporting non-standard device paths or hardware serial numbers in KSystemStats (such as Lenovo, Dell, and Apple hardware), and fixes manual battery configuration.

### Key Changes
- **Universal Battery Discovery**: Updated `PATTERNS.BATTERY` regex to `^power\/((?!all)[^/]+)\/chargePercentage$`. This matches all battery objects registered by KSystemStats (`plugins/power/power.cpp`), including serial numbers (e.g. `L19M3PF5`, `01234`) and standard names (`BAT0`, `battery_BAT0`, `macsmc-battery`).
- **Normalized Sensor Resolution**: Refactored `_resolvedBase` in `BatterySensors.qml` to verify sensor existence against `HardwareDiscovery` rather than forcibly prepending `"battery_"` or generating duplicate `"power/power/..."` paths.
- **Strict Existence Guard**: Ensured invalid manual device entries resolve to an empty string so `hasBattery` evaluates to `false`, preventing phantom battery rows showing `"---"`.
- **Settings UX**: Replaced the free-text `TextField` in `configMetrics.qml` with a native `ComboBox` listing all discovered batteries (`metricsPage.batteryList`), matching the network interface selector pattern.

## Related Issue

Fixes #97 

## Testing

- [x] Tested on Plasma 6.7.4
- [x] Distro: Fedora 44
- [x] Widget installs cleanly with `install.sh`
- [x] Widget displays correctly in the panel