### PR TITLE
fix: align storage form labels and distinguish multi-SSD devices (fix #102))

### DIFF
--- a/contents/ui/configPanelOrder.qml
+++ b/contents/ui/configPanelOrder.qml
@@ -17,6 +17,7 @@ KCM.SimpleKCM {
     property string cfg_tempLabel: "System"
     property string cfg_netLabel: "NET"
     property string cfg_diskLabel: "DSK"
+    property string cfg_diskLabels: "{}"
     property string cfg_fanLabel: "FAN"
     property string cfg_batLabel: "BAT"
 
@@ -37,6 +38,28 @@ KCM.SimpleKCM {
             return Qt.resolvedUrl("../icons/" + str + ".svg");
         }
         return name;
+    }
+
+    function getDiskDisplayName(did) {
+        if (!did) return "";
+        var custom = metricConfig.parseDiskLabels();
+        if (custom && custom[did]) return custom[did];
+
+        var disks = discovery.discoveredDisks || [];
+        var nvmeDisks = [];
+        for (var i = 0; i < disks.length; i++) {
+            if (disks[i].id.indexOf("nvme") !== -1) {
+                nvmeDisks.push(disks[i].id);
+            }
+        }
+        if (did.indexOf("nvme") !== -1) {
+            if (nvmeDisks.length > 1) {
+                var idx = nvmeDisks.indexOf(did);
+                return "NVMe " + (idx !== -1 ? (idx + 1) : did);
+            }
+            return "NVMe";
+        }
+        return did;
     }
 
     // Computed list of pinned items
@@ -157,6 +180,9 @@ KCM.SimpleKCM {
                 previewVal = subKey === "down" ? "↓ 1.2MB" : (subKey === "up" ? "↑ 240KB" : "192.168.1.1");
             }
         } else if (group === "disk") {
+            if (devId) {
+                displayName = panelOrderPage.getDiskDisplayName(devId) + " " + subLabel;
+            }
             previewVal = subKey === "read" ? "↓ 45MB" : (subKey === "write" ? "↑ 12MB" : (subKey === "usage" ? "45%" : (subKey === "space" ? "220/512G" : "54°C")));
         } else if (group === "fan") {
             previewVal = "2400 RPM";
@@ -280,7 +306,7 @@ KCM.SimpleKCM {
         ];
         for (var di = 0; di < disks.length; di++) {
             var did = disks[di].id;
-            var dName = did.indexOf("nvme") !== -1 ? "NVMe" : did;
+            var dName = panelOrderPage.getDiskDisplayName(did);
             diskItems.push({ id: "disk:" + did + "/read", label: dName + " Read", icon: "network-download-symbolic" });
             diskItems.push({ id: "disk:" + did + "/write", label: dName + " Write", icon: "network-upload-symbolic" });
             diskItems.push({ id: "disk:" + did + "/temp", label: dName + " Temp", icon: "temperature-symbolic" });
@@ -512,6 +538,7 @@ KCM.SimpleKCM {
                 id: catFlow
                 required property var modelData
                 Kirigami.FormData.label: catFlow.modelData.title + ":"
+                Kirigami.FormData.labelAlignment: Qt.AlignTop
                 Layout.fillWidth: true
                 spacing: Kirigami.Units.smallSpacing
 

--- a/contents/ui/configPanelOrder.qml
+++ b/contents/ui/configPanelOrder.qml
@@ -53,9 +53,10 @@ KCM.SimpleKCM {
             }
         }
         if (did.indexOf("nvme") !== -1) {
+            var idx = nvmeDisks.indexOf(did);
+            if (idx === -1) return did;
             if (nvmeDisks.length > 1) {
-                var idx = nvmeDisks.indexOf(did);
-                return "NVMe " + (idx !== -1 ? (idx + 1) : did);
+                return "NVMe " + (idx + 1);
             }
             return "NVMe";
         }

--- a/contents/ui/models/HardwareDiscovery.qml
+++ b/contents/ui/models/HardwareDiscovery.qml
@@ -127,12 +127,12 @@ Item {
         var diskTempSet = {};
 
         var pGpu = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.GPU : /^gpu\/(gpu\d+)\/usage$/;
-        var pDisk = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.DISK_READ : /^disk\/(nvme\d+n\d+|sd[a-z]+)\/read$/;
+        var pDisk = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.DISK_READ : /^disk\/(nvme\d+(?:c\d+)?n\d+|nvme\d+|sd[a-z]+|vd[a-z]+|xvd[a-z]+|mmcblk\d+)\/read$/;
         var pFan = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.FAN : /^(lmsensors|cpu|gpu)\/.*\/fan\d+$/i;
         var pCore = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.CPU_CORE : /^cpu\/(cpu\d+)\/usage$/;
         var pNet = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.NETWORK_IFACE : /^network\/([^/]+)\/download$/;
         var pBat = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.BATTERY : /^power\/([^/]+)\/chargePercentage$/;
-        var pDiskTemp = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.DISK_TEMP : /^(?:disk\/(?:nvme\d+n\d+|sd[a-z]+)\/temperature|lmsensors\/(?:nvme-pci-[^/]+|drivetemp-scsi-[^/]+|scsi-[^/]+|drivetemp-[^/]+)\/temp\d+)$/;
+        var pDiskTemp = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.DISK_TEMP : /^(?:disk\/(?:nvme\d+(?:c\d+)?n\d+|nvme\d+|sd[a-z]+|vd[a-z]+|xvd[a-z]+|mmcblk\d+)\/temperature|lmsensors\/(?:nvme-pci-[^/]+|drivetemp-scsi-[^/]+|scsi-[^/]+|drivetemp-[^/]+)\/temp\d+)$/;
 
         for (var row = 0; row < rowCount; row++) {
             var idx = flatSensors.index(row, 0);

--- a/contents/ui/models/MetricDefinitions.js
+++ b/contents/ui/models/MetricDefinitions.js
@@ -155,8 +155,8 @@ function isBundledIcon(name) {
 var PATTERNS = {
     CPU_CORE: /^cpu\/(cpu\d+)\/usage$/,
     GPU: /^gpu\/(gpu\d+)\/usage$/,
-    DISK_READ: /^disk\/(nvme\d+n\d+|sd[a-z]+)\/read$/,
-    DISK_TEMP: /^(?:disk\/(?:nvme\d+n\d+|sd[a-z]+)\/temperature|lmsensors\/(?:nvme-pci-[^/]+|drivetemp-scsi-[^/]+|scsi-[^/]+|drivetemp-[^/]+)\/temp\d+)$/,
+    DISK_READ: /^disk\/(nvme\d+(?:c\d+)?n\d+|nvme\d+|sd[a-z]+|vd[a-z]+|xvd[a-z]+|mmcblk\d+)\/read$/,
+    DISK_TEMP: /^(?:disk\/(?:nvme\d+(?:c\d+)?n\d+|nvme\d+|sd[a-z]+|vd[a-z]+|xvd[a-z]+|mmcblk\d+)\/temperature|lmsensors\/(?:nvme-pci-[^/]+|drivetemp-scsi-[^/]+|scsi-[^/]+|drivetemp-[^/]+)\/temp\d+)$/,
     FAN: /^(lmsensors|cpu|gpu)\/.*\/fan\d+$/i,
     NETWORK_IFACE: /^network\/([^/]+)\/download$/,
     TEMP_LMSENSORS: /^lmsensors\/(.+)\/temp\d+$/,

--- a/contents/ui/sensors/DiskSensors.qml
+++ b/contents/ui/sensors/DiskSensors.qml
@@ -299,8 +299,7 @@
         property var _unplugged: ({})
 
         function _udiToDisk(udi) {
-            // e.g. /org/freedesktop/UDisks2/block_devices/sdb1 -> "sdb"
-            var m = String(udi).match(/\/(sd[a-z]+|nvme\d+n\d+)(?:p?\d+)?$/);
+            var m = String(udi).match(/\/(sd[a-z]+|nvme\d+(?:c\d+)?n\d+|nvme\d+|vd[a-z]+|xvd[a-z]+|mmcblk\d+)(?:p?\d+)?$/);
             return m ? m[1] : "";
         }
 
@@ -351,7 +350,7 @@
 
         function _refreshTempSensors() {
             if (!discovery) return;
-            var pattern = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.DISK_TEMP : /^(?:disk\/(?:nvme\d+n\d+|sd[a-z]+)\/temperature|lmsensors\/(?:nvme-pci-[^/]+|drivetemp-scsi-[^/]+|scsi-[^/]+|drivetemp-[^/]+)\/temp\d+)$/;
+            var pattern = MetricDefinitions.PATTERNS ? MetricDefinitions.PATTERNS.DISK_TEMP : /^(?:disk\/(?:nvme\d+(?:c\d+)?n\d+|nvme\d+|sd[a-z]+|vd[a-z]+|xvd[a-z]+|mmcblk\d+)\/temperature|lmsensors\/(?:nvme-pci-[^/]+|drivetemp-scsi-[^/]+|scsi-[^/]+|drivetemp-[^/]+)\/temp\d+)$/;
             var found = discovery.queryIds(pattern);
             for (var i = 0; i < _discovered.length; i++) {
                 var direct = "disk/" + _discovered[i].id + "/temperature";


### PR DESCRIPTION
## Description

- **Align category form labels**: Sets `Kirigami.FormData.labelAlignment: Qt.AlignTop` on the metric palette flow so multi-line category labels (such as `Storage (Disks):` and `Processor (CPU):`) align with the top row instead of centering vertically.
- **Distinguish multi-SSD devices**: Resolves duplicate `NVMe` button names by numbering multiple NVMe drives (`NVMe 1`, `NVMe 2`) while keeping `NVMe` for single-drive setups, and respects user-configured custom disk names from Settings.
- **Expand disk discovery patterns**: Extends `DISK_READ` and `DISK_TEMP` regexes to support NVMe multipath namespaces (`nvme0c0n1`), non-namespaced NVMe (`nvme0`), VirtIO (`vda`), Xen (`xvda`), and eMMC storage (`mmcblk0`).

## Related Issue

Fixes #102

## Testing

- [x] Tested on KDE Plasma 6.7.4
- [x] Distro: Fedora 44
- [x] Widget installs cleanly with `install.sh`
- [x] Widget displays correctly in the panel

## Screenshots

<img width="1049" height="930" alt="image" src="https://github.com/user-attachments/assets/9596dece-809b-4251-acc8-e7a3600d85de" />

